### PR TITLE
fix: resolve black screen and improve macOS 26 capture reliability

### DIFF
--- a/MacHost/Sources/AppDelegate.swift
+++ b/MacHost/Sources/AppDelegate.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import Combine
 import ApplicationServices
 import os.log
+@preconcurrency import ScreenCaptureKit
 
 // Debug file logger - writes to /tmp/sidescreen.log
 func debugLog(_ message: String) {
@@ -160,15 +161,29 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func checkPermissions() async {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        debugLog("checkPermissions — macOS \(version.majorVersion).\(version.minorVersion).\(version.patchVersion)")
+
         // Check Screen Recording permission using CoreGraphics API
         let hasScreenCapture = CGPreflightScreenCaptureAccess()
         await MainActor.run {
             settings.hasScreenRecordingPermission = hasScreenCapture
         }
         if hasScreenCapture {
-            print("✅ Screen recording permission granted")
+            debugLog("Screen recording permission granted (CGPreflight)")
+
+            // On macOS 26+, also verify ScreenCaptureKit is actually functional
+            if version.majorVersion >= 26 {
+                do {
+                    let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+                    debugLog("SCShareableContent verification OK — \(content.displays.count) displays found")
+                } catch {
+                    debugLog("WARNING: CGPreflight OK but SCShareableContent failed on macOS 26: \(error.localizedDescription)")
+                    debugLog("CGDisplayStream fallback will likely activate at capture time")
+                }
+            }
         } else {
-            print("⚠️  Screen recording permission not granted yet")
+            debugLog("Screen recording permission not granted yet")
             // Prompt user to grant permission
             CGRequestScreenCaptureAccess()
         }
@@ -285,16 +300,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     func showPermissionAlert() {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        let isMacOS26 = version.majorVersion >= 26
+
         let alert = NSAlert()
-        alert.messageText = "Screen Recording Permission Required"
-        alert.informativeText = "Please grant Screen Recording permission in System Settings > Privacy & Security."
+        if isMacOS26 {
+            alert.messageText = "Screen & System Audio Recording Permission Required"
+            alert.informativeText = "Please grant Screen & System Audio Recording permission in System Settings > Privacy & Security."
+        } else {
+            alert.messageText = "Screen Recording Permission Required"
+            alert.informativeText = "Please grant Screen Recording permission in System Settings > Privacy & Security."
+        }
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Open System Settings")
         alert.addButton(withTitle: "Later")
 
         let response = alert.runModal()
         if response == .alertFirstButtonReturn {
-            NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!)
+            if isMacOS26 {
+                NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!)
+            } else {
+                NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!)
+            }
         }
     }
 
@@ -334,9 +361,24 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             virtualDisplayManager?.restoreDisplayPosition()
 
+            // Verify display is registered in the system
+            if let vdm = virtualDisplayManager {
+                let registered = vdm.verifyDisplayRegistered()
+                if !registered {
+                    debugLog("WARNING: Virtual display not found in online display list — capture may fail")
+                }
+            }
+
             // Setup capture
             guard let displayID = virtualDisplayManager?.displayID else { return }
             screenCapture = try await ScreenCapture()
+            screenCapture?.onCaptureMethodChanged = { [weak self] method in
+                guard let self = self else { return }
+                debugLog("Capture method: \(method)")
+                Task { @MainActor in
+                    self.settings.captureMethod = method
+                }
+            }
             try await screenCapture?.setupForVirtualDisplay(displayID, refreshRate: settings.effectiveRefreshRate)
 
             // Setup server

--- a/MacHost/Sources/ScreenCapture.swift
+++ b/MacHost/Sources/ScreenCapture.swift
@@ -3,19 +3,59 @@ import Foundation
 import VideoToolbox
 import CoreMedia
 import CoreGraphics
+import CoreVideo
+import IOSurface
+
+// MARK: - SCStreamDelegate
+
+private class StreamDelegate: NSObject, SCStreamDelegate {
+    var onStreamError: ((Error) -> Void)?
+
+    func stream(_ stream: SCStream, didStopWithError error: Error) {
+        let nsError = error as NSError
+        debugLog("SCStream stopped with error — domain: \(nsError.domain), code: \(nsError.code), description: \(nsError.localizedDescription)")
+        onStreamError?(error)
+    }
+}
+
+// MARK: - ScreenCapture
 
 class ScreenCapture {
     private var stream: SCStream?
     private var streamOutput: StreamOutput?
+    private var streamDelegate: StreamDelegate?
     private var encoder: VideoEncoder?
     private var display: SCDisplay?
     private var virtualDisplayID: CGDirectDisplayID?
     private var refreshRate: Int = 60
 
-    var displayWidth: Int { display?.width ?? 1920 }
-    var displayHeight: Int { display?.height ?? 1080 }
+    // Continuous frame-flow monitor
+    private var lastFrameTime: DispatchTime?
+    private var frameMonitorTimer: DispatchSourceTimer?
+    private var hasReceivedFirstFrame = false
+    private var restartAttempted = false
 
-    init() async throws {}
+    // CGDisplayStream fallback
+    private var cgDisplayStream: CGDisplayStream?
+    private var fallbackActive = false
+
+    // Streaming parameters (saved for restart)
+    private weak var currentServer: StreamingServer?
+    private var currentBitrateMbps: Int = 20
+    private var currentQuality: String = "medium"
+    private var currentGamingBoost: Bool = false
+    private var currentFrameRate: Int = 60
+
+    /// Callback when capture method changes (e.g. SCStream → CGDisplayStream fallback)
+    var onCaptureMethodChanged: ((String) -> Void)?
+
+    var displayWidth: Int { display?.width ?? Int(CGDisplayPixelsWide(virtualDisplayID ?? 0)) }
+    var displayHeight: Int { display?.height ?? Int(CGDisplayPixelsHigh(virtualDisplayID ?? 0)) }
+
+    init() async throws {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        debugLog("ScreenCapture init — macOS \(version.majorVersion).\(version.minorVersion).\(version.patchVersion)")
+    }
 
     /// Setup screen capture for a specific virtual display
     func setupForVirtualDisplay(_ displayID: CGDirectDisplayID, refreshRate: Int = 60) async throws {
@@ -25,6 +65,27 @@ class ScreenCapture {
         try await setupStream()
     }
 
+    // MARK: - SCShareableContent with timeout
+
+    private func getShareableContentWithTimeout(seconds: Int = 10) async throws -> SCShareableContent {
+        try await withThrowingTaskGroup(of: SCShareableContent.self) { group in
+            group.addTask {
+                try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(seconds) * 1_000_000_000)
+                throw NSError(domain: "ScreenCapture", code: 10,
+                    userInfo: [NSLocalizedDescriptionKey: "SCShareableContent timed out after \(seconds)s (possible Apple bug FB12114396)"])
+            }
+
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+    }
+
+    // MARK: - Display setup
+
     private func setupDisplay() async throws {
         guard let virtualDisplayID = virtualDisplayID else {
             throw NSError(domain: "ScreenCapture", code: 1,
@@ -32,7 +93,19 @@ class ScreenCapture {
         }
 
         for attempt in 1...5 {
-            let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+            let content: SCShareableContent
+            do {
+                content = try await getShareableContentWithTimeout(seconds: 10)
+            } catch {
+                debugLog("SCShareableContent attempt \(attempt) failed: \(error.localizedDescription)")
+                if attempt < 5 {
+                    try await Task.sleep(nanoseconds: 1_000_000_000)
+                    continue
+                }
+                throw error
+            }
+
+            debugLog("SCShareableContent returned \(content.displays.count) displays: \(content.displays.map { $0.displayID })")
 
             if let virtualDisplay = content.displays.first(where: { $0.displayID == virtualDisplayID }) {
                 display = virtualDisplay
@@ -41,6 +114,7 @@ class ScreenCapture {
             }
 
             if attempt < 5 {
+                debugLog("Virtual display \(virtualDisplayID) not found in attempt \(attempt), retrying...")
                 try await Task.sleep(nanoseconds: 1_000_000_000)
             }
         }
@@ -48,6 +122,8 @@ class ScreenCapture {
         throw NSError(domain: "ScreenCapture", code: 2,
             userInfo: [NSLocalizedDescriptionKey: "Virtual display with ID \(virtualDisplayID) not found after 5 attempts"])
     }
+
+    // MARK: - Stream setup
 
     private func setupStream() async throws {
         guard let display = display else {
@@ -60,6 +136,16 @@ class ScreenCapture {
         let fps = refreshRate
 
         streamOutput = StreamOutput()
+
+        let delegate = StreamDelegate()
+        delegate.onStreamError = { [weak self] error in
+            guard let self = self else { return }
+            debugLog("StreamDelegate error callback — attempting fallback")
+            if !self.fallbackActive {
+                self.attemptFallbackCapture()
+            }
+        }
+        streamDelegate = delegate
 
         let filter = SCContentFilter(display: display, excludingWindows: [])
 
@@ -74,16 +160,25 @@ class ScreenCapture {
         config.backgroundColor = .clear
         config.scalesToFit = false
 
-        let scStream = SCStream(filter: filter, configuration: config, delegate: nil)
+        let scStream = SCStream(filter: filter, configuration: config, delegate: delegate)
         try scStream.addStreamOutput(streamOutput!, type: .screen, sampleHandlerQueue: .global(qos: .userInteractive))
 
         stream = scStream
-        debugLog("Stream configured: \(width)x\(height) @ \(fps)fps")
+        debugLog("Stream configured: \(width)x\(height) @ \(fps)fps (with delegate)")
     }
 
+    // MARK: - Start streaming
+
     func startStreaming(to server: StreamingServer?, bitrateMbps: Int = 20, quality: String = "medium", gamingBoost: Bool = false, frameRate: Int = 60) {
-        let width = display?.width ?? 1920
-        let height = display?.height ?? 1080
+        // Save parameters for potential restart
+        currentServer = server
+        currentBitrateMbps = bitrateMbps
+        currentQuality = quality
+        currentGamingBoost = gamingBoost
+        currentFrameRate = frameRate
+
+        let width = displayWidth
+        let height = displayHeight
 
         encoder = VideoEncoder(width: width, height: height, bitrateMbps: bitrateMbps, quality: quality, gamingBoost: gamingBoost, frameRate: frameRate)
         encoder?.onEncodedFrame = { [weak server] data, timestamp, isKeyframe in
@@ -98,8 +193,22 @@ class ScreenCapture {
         // Cache last valid pixel buffer for re-encoding when SCStream sends idle frames
         var lastPixelBuffer: CVPixelBuffer?
 
+        // Reset frame monitor state
+        lastFrameTime = nil
+        hasReceivedFirstFrame = false
+
         streamOutput?.onFrameReceived = { [weak self] sampleBuffer in
             guard let self = self else { return }
+
+            // Update frame timestamp on every frame for flow monitor
+            self.lastFrameTime = DispatchTime.now()
+
+            if !self.hasReceivedFirstFrame {
+                self.hasReceivedFirstFrame = true
+                debugLog("First frame received from SCStream")
+                self.onCaptureMethodChanged?("SCStream")
+            }
+
             let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
 
             // Backpressure: skip if encode queue already has 2+ frames pending
@@ -130,27 +239,231 @@ class ScreenCapture {
         Task {
             do {
                 try await stream?.startCapture()
-                debugLog("SCStream capture started")
+                debugLog("SCStream capture started — starting frame flow monitor (3s interval, 5s timeout)")
+                startFrameMonitor()
             } catch {
-                debugLog("Failed to start capture: \(error)")
+                debugLog("Failed to start SCStream capture: \(error)")
+                debugLog("Attempting CGDisplayStream fallback due to start failure")
+                attemptFallbackCapture()
             }
         }
     }
+
+    // MARK: - Continuous frame-flow monitor
+
+    private func startFrameMonitor() {
+        stopFrameMonitor()
+
+        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.main)
+        timer.schedule(deadline: .now() + 3.0, repeating: 3.0)
+        timer.setEventHandler { [weak self] in
+            guard let self = self, !self.fallbackActive else {
+                self?.stopFrameMonitor()
+                return
+            }
+
+            let stalled: Bool
+            if let last = self.lastFrameTime {
+                let elapsed = Double(DispatchTime.now().uptimeNanoseconds - last.uptimeNanoseconds) / 1_000_000_000
+                stalled = elapsed > 5.0
+                if stalled {
+                    debugLog("Frame flow stalled — no frames for \(String(format: "%.1f", elapsed))s, triggering fallback")
+                }
+            } else {
+                stalled = true
+                debugLog("Frame flow stalled — no frames ever received after 5s, triggering fallback")
+            }
+
+            if stalled {
+                self.stopFrameMonitor()
+                if !self.restartAttempted {
+                    debugLog("Attempting SCStream restart...")
+                    self.restartStream()
+                } else {
+                    debugLog("Restart already attempted — falling back to CGDisplayStream")
+                    self.attemptFallbackCapture()
+                }
+            }
+        }
+        timer.resume()
+        frameMonitorTimer = timer
+    }
+
+    private func stopFrameMonitor() {
+        frameMonitorTimer?.cancel()
+        frameMonitorTimer = nil
+    }
+
+    // MARK: - Stream restart
+
+    private func restartStream() {
+        restartAttempted = true
+        hasReceivedFirstFrame = false
+
+        Task {
+            do {
+                // Stop existing stream
+                try? await stream?.stopCapture()
+                stream = nil
+                streamOutput = nil
+                streamDelegate = nil
+                display = nil
+
+                // Re-setup
+                try await setupDisplay()
+                try await setupStream()
+
+                // Re-attach encoding pipeline
+                let encodeQueue = DispatchQueue(label: "encodeQueue.restart", qos: .userInteractive)
+                var pendingEncodes: Int32 = 0
+                var lastPixelBuffer: CVPixelBuffer?
+
+                streamOutput?.onFrameReceived = { [weak self] sampleBuffer in
+                    guard let self = self else { return }
+
+                    self.lastFrameTime = DispatchTime.now()
+
+                    if !self.hasReceivedFirstFrame {
+                        self.hasReceivedFirstFrame = true
+                        debugLog("First frame received after SCStream restart")
+                        self.onCaptureMethodChanged?("SCStream")
+                    }
+
+                    let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+                    let pending = OSAtomicAdd32(0, &pendingEncodes)
+                    if pending >= 2 { return }
+
+                    if let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) {
+                        lastPixelBuffer = imageBuffer
+                        OSAtomicIncrement32(&pendingEncodes)
+                        encodeQueue.async {
+                            self.encoder?.encode(pixelBuffer: imageBuffer, presentationTimeStamp: pts)
+                            OSAtomicDecrement32(&pendingEncodes)
+                        }
+                    } else if let cached = lastPixelBuffer {
+                        OSAtomicIncrement32(&pendingEncodes)
+                        encodeQueue.async {
+                            self.encoder?.encode(pixelBuffer: cached, presentationTimeStamp: pts)
+                            OSAtomicDecrement32(&pendingEncodes)
+                        }
+                    }
+                }
+
+                try await stream?.startCapture()
+                debugLog("SCStream restarted — starting frame flow monitor")
+                startFrameMonitor()
+            } catch {
+                debugLog("SCStream restart failed: \(error) — falling back to CGDisplayStream")
+                attemptFallbackCapture()
+            }
+        }
+    }
+
+    // MARK: - CGDisplayStream fallback
+
+    private func attemptFallbackCapture() {
+        guard let displayID = virtualDisplayID, !fallbackActive else {
+            debugLog("Fallback skipped — no displayID or already active")
+            return
+        }
+        fallbackActive = true
+
+        // Stop SCStream if still running
+        Task {
+            try? await stream?.stopCapture()
+            stream = nil
+            streamOutput = nil
+            streamDelegate = nil
+        }
+
+        let width = Int(CGDisplayPixelsWide(displayID))
+        let height = Int(CGDisplayPixelsHigh(displayID))
+
+        debugLog("CGDisplayStream fallback — display \(displayID) (\(width)x\(height))")
+
+        let pixelFormat = Int32(kCVPixelFormatType_420YpCbCr8BiPlanarFullRange)
+        let queue = DispatchQueue(label: "com.sidescreen.cgdisplaystream", qos: .userInteractive)
+
+        guard let displayStream = CGDisplayStream(
+            dispatchQueueDisplay: displayID,
+            outputWidth: width,
+            outputHeight: height,
+            pixelFormat: pixelFormat,
+            properties: nil,
+            queue: queue,
+            handler: { [weak self] status, displayTime, frameSurface, updateRef in
+                guard let self = self, let surface = frameSurface else { return }
+
+                var unmanagedPB: Unmanaged<CVPixelBuffer>?
+                let attrs: [String: Any] = [
+                    kCVPixelBufferIOSurfacePropertiesKey as String: [:] as [String: Any]
+                ]
+                let cvReturn = CVPixelBufferCreateWithIOSurface(
+                    kCFAllocatorDefault,
+                    surface,
+                    attrs as CFDictionary,
+                    &unmanagedPB
+                )
+
+                guard cvReturn == kCVReturnSuccess, let pb = unmanagedPB?.takeRetainedValue() else { return }
+
+                let pts = CMTime(value: CMTimeValue(displayTime), timescale: 1_000_000_000)
+                self.encoder?.encode(pixelBuffer: pb, presentationTimeStamp: pts)
+            }
+        ) else {
+            debugLog("Failed to create CGDisplayStream — fallback unavailable")
+            fallbackActive = false
+            return
+        }
+
+        let startResult = displayStream.start()
+        if startResult == .success {
+            cgDisplayStream = displayStream
+            debugLog("CGDisplayStream fallback started successfully")
+            onCaptureMethodChanged?("CGDisplayStream (fallback)")
+        } else {
+            debugLog("CGDisplayStream.start() failed: \(startResult)")
+            fallbackActive = false
+        }
+    }
+
+    // MARK: - Settings update
 
     func updateEncoderSettings(bitrateMbps: Int, quality: String, gamingBoost: Bool) {
         encoder?.updateSettings(bitrateMbps: bitrateMbps, quality: quality, gamingBoost: gamingBoost)
     }
 
+    // MARK: - Stop streaming
+
     func stopStreaming() {
+        // Cancel frame flow monitor
+        stopFrameMonitor()
+
+        // Stop SCStream
         Task {
             do {
                 try await stream?.stopCapture()
             } catch {
-                debugLog("Failed to stop capture: \(error)")
+                debugLog("Failed to stop SCStream capture: \(error)")
             }
         }
+
+        // Stop CGDisplayStream fallback
+        if fallbackActive {
+            cgDisplayStream?.stop()
+            cgDisplayStream = nil
+            fallbackActive = false
+            debugLog("CGDisplayStream fallback stopped")
+        }
+
+        // Reset state
+        lastFrameTime = nil
+        hasReceivedFirstFrame = false
+        restartAttempted = false
     }
 }
+
+// MARK: - StreamOutput
 
 class StreamOutput: NSObject, SCStreamOutput {
     var onFrameReceived: ((CMSampleBuffer) -> Void)?

--- a/MacHost/Sources/SettingsWindow.swift
+++ b/MacHost/Sources/SettingsWindow.swift
@@ -472,18 +472,27 @@ struct SettingsView: View {
                             VStack(alignment: .leading, spacing: 12) {
                                 StatusRow(title: "Virtual Display", status: settings.displayCreated ? "Active" : "Inactive", color: settings.displayCreated ? .green : .secondary)
                                 StatusRow(title: "Client Connected", status: settings.clientConnected ? "Yes" : "No", color: settings.clientConnected ? .green : .secondary)
-                                StatusRow(title: "Screen Recording", status: settings.hasScreenRecordingPermission ? "Granted" : "Required", color: settings.hasScreenRecordingPermission ? .green : .red)
+                                StatusRow(
+                                    title: ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26 ? "Screen & System Audio" : "Screen Recording",
+                                    status: settings.hasScreenRecordingPermission ? "Granted" : "Required",
+                                    color: settings.hasScreenRecordingPermission ? .green : .red
+                                )
                                 StatusRow(title: "Accessibility", status: settings.hasAccessibilityPermission ? "Granted" : "Optional", color: settings.hasAccessibilityPermission ? .green : .orange)
+                                if settings.isRunning {
+                                    StatusRow(title: "Capture Method", status: settings.captureMethod, color: settings.captureMethod.contains("fallback") ? .orange : .green)
+                                }
 
                                 if !settings.hasScreenRecordingPermission {
                                     VStack(alignment: .leading, spacing: 8) {
                                         HStack(spacing: 6) {
                                             Image(systemName: "exclamationmark.triangle.fill")
                                                 .foregroundColor(.orange)
-                                            Text("Screen Recording Required")
+                                            Text(ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26 ? "Screen & System Audio Recording Required" : "Screen Recording Required")
                                                 .font(.system(size: 12, weight: .medium))
                                         }
-                                        Text("Required to capture the virtual display.")
+                                        Text(ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26
+                                            ? "Required to capture the virtual display. Go to System Settings > Privacy & Security > Screen & System Audio Recording."
+                                            : "Required to capture the virtual display.")
                                             .font(.system(size: 11))
                                             .foregroundColor(.secondary)
                                         Button(action: {
@@ -867,6 +876,7 @@ class DisplaySettings: ObservableObject {
     @Published var isRunning = false
     @Published var currentFPS: Double = 0
     @Published var currentBitrate: Double = 0
+    @Published var captureMethod: String = "Initializing..."
 
     var onToggleServer: (() -> Void)?
 

--- a/MacHost/Sources/VideoEncoder.swift
+++ b/MacHost/Sources/VideoEncoder.swift
@@ -51,7 +51,7 @@ class VideoEncoder {
         )
 
         guard status == noErr, let session = session else {
-            print("❌ Failed to create compression session: \(status)")
+            debugLog("Failed to create compression session: \(status)")
             return
         }
 
@@ -106,7 +106,7 @@ class VideoEncoder {
         VTCompressionSessionPrepareToEncodeFrames(session)
 
         let mode = gamingBoost ? "🎮 GAMING BOOST" : quality.uppercased()
-        print("✅ VideoToolbox encoder configured (H.265, \(bitrateMbps)Mbps, \(frameRate)fps, \(mode))")
+        debugLog("VideoToolbox encoder configured (H.265, \(bitrateMbps)Mbps, \(frameRate)fps, \(mode))")
     }
 
     func encode(pixelBuffer: CVPixelBuffer, presentationTimeStamp: CMTime) {

--- a/MacHost/Sources/VirtualDisplayManager.swift
+++ b/MacHost/Sources/VirtualDisplayManager.swift
@@ -242,6 +242,28 @@ class VirtualDisplayManager {
         }
     }
 
+    /// Verify the virtual display is registered in the system display list
+    func verifyDisplayRegistered() -> Bool {
+        guard let displayID = displayID else {
+            debugLog("verifyDisplayRegistered: no displayID set")
+            return false
+        }
+
+        var onlineDisplays = [CGDirectDisplayID](repeating: 0, count: 16)
+        var displayCount: UInt32 = 0
+        let err = CGGetOnlineDisplayList(16, &onlineDisplays, &displayCount)
+
+        guard err == .success else {
+            debugLog("verifyDisplayRegistered: CGGetOnlineDisplayList failed with \(err)")
+            return false
+        }
+
+        let onlineIDs = Array(onlineDisplays.prefix(Int(displayCount)))
+        let found = onlineIDs.contains(displayID)
+        debugLog("verifyDisplayRegistered: displayID \(displayID) \(found ? "FOUND" : "NOT FOUND") in online displays \(onlineIDs)")
+        return found
+    }
+
     /// Destroy the virtual display
     func destroyDisplay() {
         if virtualDisplay != nil {


### PR DESCRIPTION
## Summary

- **Mac**: Replace one-shot frame watchdog with continuous 3s monitor that detects SCStream stalls and triggers CGDisplayStream fallback. Add SCStreamDelegate for error handling. Convert all `print()` to `debugLog()` across VideoEncoder and StreamingServer for full pipeline visibility in `/tmp/sidescreen.log`. Gate frame sending behind `connectionReady` flag to prevent race condition where video frames are sent before display config.

- **Android**: Fix black screen caused by HEVC decoder initialization failure. Defer decoder creation until display config arrives from server (instead of using hardcoded resolution at surface creation). Enumerate all HEVC decoders on the device and fall back to software decoder (`c2.android.hevc.decoder`) when hardware decoder can't handle the stream resolution (e.g. Qualcomm OMX.qcom limited to 1080p, rejecting 1920x1200). Fix `surfaceDestroyed` to only release decoder without killing the TCP connection.

## Test plan

- [ ] Start SideScreen.app on Mac, connect Android client via USB — verify video displays (no black screen)
- [ ] Check `/tmp/sidescreen.log` shows full pipeline: encoder configured, server listening, client connected, fps/Mbps stats
- [ ] Verify SCStream stall detection works: if frames stop, fallback to CGDisplayStream triggers within ~5s
- [ ] Test on devices with limited HEVC hardware decoder (e.g. older Qualcomm) — should fall back to software decoder
- [ ] Verify reconnection works cleanly (disconnect and reconnect without restarting app)