### PR TITLE
feat: add p-frame compression

### DIFF
--- a/MacHost/Sources/AppDelegate.swift
+++ b/MacHost/Sources/AppDelegate.swift
@@ -94,7 +94,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 self.screenCapture?.updateEncoderSettings(
                     bitrateMbps: self.settings.effectiveBitrate,
                     quality: self.settings.effectiveQuality,
-                    gamingBoost: gamingBoost
+                    gamingBoost: gamingBoost,
+                    keyFrameInterval: self.settings.effectiveKeyFrameInterval
                 )
             }
             .store(in: &cancellables)
@@ -108,12 +109,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 self.screenCapture?.updateEncoderSettings(
                     bitrateMbps: bitrate,
                     quality: quality,
-                    gamingBoost: false
+                    gamingBoost: false,
+                    keyFrameInterval: self.settings.effectiveKeyFrameInterval
                 )
             }
             .store(in: &cancellables)
 
-        // Observer cho rotation changes - send to connected client immediately
+        // Observer for keyframe interval changes
+        settings.$keyFrameInterval
+            .dropFirst()
+            .sink { [weak self] _ in
+                guard let self = self, self.settings.isRunning else { return }
+                let interval = self.settings.effectiveKeyFrameInterval
+                self.screenCapture?.updateEncoderSettings(
+                    bitrateMbps: self.settings.effectiveBitrate,
+                    quality: self.settings.effectiveQuality,
+                    gamingBoost: self.settings.gamingBoost,
+                    keyFrameInterval: interval
+                )
+            }
+            .store(in: &cancellables)
+
+         // Observer cho rotation changes - send to connected client immediately
         settings.$rotation
             .dropFirst()
             .sink { [weak self] rotation in
@@ -396,6 +413,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             streamingServer?.setDisplaySize(width: physWidth, height: physHeight, rotation: settings.rotation)
             streamingServer?.onClientConnected = { [weak self] in
                 guard let self = self else { return }
+                self.screenCapture?.requestKeyframeOrReplayCachedFrame()
                 Task { @MainActor in
                     self.settings.clientConnected = true
                 }
@@ -419,7 +437,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 bitrateMbps: settings.effectiveBitrate,
                 quality: settings.effectiveQuality,
                 gamingBoost: settings.gamingBoost,
-                frameRate: settings.effectiveRefreshRate
+                frameRate: settings.effectiveRefreshRate,
+                keyFrameInterval: settings.effectiveKeyFrameInterval
             )
 
             await MainActor.run {

--- a/MacHost/Sources/ScreenCapture.swift
+++ b/MacHost/Sources/ScreenCapture.swift
@@ -22,6 +22,10 @@ private class StreamDelegate: NSObject, SCStreamDelegate {
 // MARK: - ScreenCapture
 
 class ScreenCapture {
+    private struct KeyframeRequestState {
+        var pendingEncoderCreationRequest = false
+    }
+
     private var stream: SCStream?
     private var streamOutput: StreamOutput?
     private var streamDelegate: StreamDelegate?
@@ -29,6 +33,7 @@ class ScreenCapture {
     private var display: SCDisplay?
     private var virtualDisplayID: CGDirectDisplayID?
     private var refreshRate: Int = 60
+    private let keyframeRequestLock = OSAllocatedUnfairLock(initialState: KeyframeRequestState())
 
     // Thread-safe state for cross-thread access (frame output queue + main queue)
     private let stateLock = OSAllocatedUnfairLock(initialState: FrameMonitorState())
@@ -58,7 +63,37 @@ class ScreenCapture {
     private var pendingEncodes: Int32 = 0
     private var lastPixelBuffer: CVPixelBuffer?
 
-    /// Callback when capture method changes (e.g. SCStream → CGDisplayStream fallback)
+    /// Force the encoder to emit a keyframe on the next frame.
+    /// Called synchronously so the pendingForceKeyframe flag is set before any
+    /// encoding queue (SCStream's encodeQueue or CGDisplayStream's fallback queue)
+    /// processes the next frame.
+    func requestKeyframe() {
+        if let encoder {
+            encoder.requestKeyframe()
+            return
+        }
+
+        keyframeRequestLock.withLock { $0.pendingEncoderCreationRequest = true }
+    }
+
+    /// Force a keyframe for the next frame, or immediately re-encode the last
+    /// captured frame if the display is currently idle.
+    func requestKeyframeOrReplayCachedFrame() {
+        requestKeyframe()
+
+        guard let encoder, let cached = lastPixelBuffer else { return }
+
+        let pts = CMTime(
+            value: CMTimeValue(DispatchTime.now().uptimeNanoseconds / 1000),
+            timescale: 1_000_000
+        )
+
+        encodeQueue?.async {
+            encoder.encode(pixelBuffer: cached, presentationTimeStamp: pts)
+        }
+    }
+
+     /// Callback when capture method changes (e.g. SCStream → CGDisplayStream fallback)
     var onCaptureMethodChanged: ((String) -> Void)?
 
     var displayWidth: Int {
@@ -253,7 +288,7 @@ class ScreenCapture {
 
     // MARK: - Start streaming
 
-    func startStreaming(to server: StreamingServer?, bitrateMbps: Int = 20, quality: String = "medium", gamingBoost: Bool = false, frameRate: Int = 60) {
+    func startStreaming(to server: StreamingServer?, bitrateMbps: Int = 20, quality: String = "medium", gamingBoost: Bool = false, frameRate: Int = 60, keyFrameInterval: Int = 30) {
         // Save parameters for potential restart
         currentServer = server
         currentBitrateMbps = bitrateMbps
@@ -264,7 +299,15 @@ class ScreenCapture {
         let width = displayWidth
         let height = displayHeight
 
-        encoder = VideoEncoder(width: width, height: height, bitrateMbps: bitrateMbps, quality: quality, gamingBoost: gamingBoost, frameRate: frameRate)
+        encoder = VideoEncoder(width: width, height: height, bitrateMbps: bitrateMbps, quality: quality, gamingBoost: gamingBoost, frameRate: frameRate, keyFrameInterval: keyFrameInterval)
+        let shouldForceInitialKeyframe = keyframeRequestLock.withLock { state -> Bool in
+            guard state.pendingEncoderCreationRequest else { return false }
+            state.pendingEncoderCreationRequest = false
+            return true
+        }
+        if shouldForceInitialKeyframe {
+            encoder?.requestKeyframe()
+        }
         encoder?.onEncodedFrame = { [weak server] data, timestamp, isKeyframe in
             server?.sendFrame(data, timestamp: timestamp, isKeyframe: isKeyframe)
         }
@@ -469,8 +512,8 @@ class ScreenCapture {
 
     // MARK: - Settings update
 
-    func updateEncoderSettings(bitrateMbps: Int, quality: String, gamingBoost: Bool) {
-        encoder?.updateSettings(bitrateMbps: bitrateMbps, quality: quality, gamingBoost: gamingBoost)
+    func updateEncoderSettings(bitrateMbps: Int, quality: String, gamingBoost: Bool, keyFrameInterval: Int = 30) {
+        encoder?.updateSettings(bitrateMbps: bitrateMbps, quality: quality, gamingBoost: gamingBoost, keyFrameInterval: keyFrameInterval)
     }
 
     // MARK: - Stop streaming

--- a/MacHost/Sources/SettingsWindow.swift
+++ b/MacHost/Sources/SettingsWindow.swift
@@ -481,6 +481,44 @@ struct SettingsView: View {
                                             .foregroundColor(.green)
                                     }
                                 }
+
+                                // Encoding Mode
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text("Encoding Mode")
+                                        .font(.system(size: 11))
+                                        .foregroundColor(.secondary)
+
+                                    Picker("", selection: $settings.keyFrameInterval) {
+                                        Text("All-Intra").tag(1)
+                                        Text("Low Compression").tag(10)
+                                        Text("Balanced").tag(30)
+                                        Text("Max Compression").tag(60)
+                                     }
+                                     .pickerStyle(.segmented)
+                                     .disabled(settings.gamingBoost)
+
+                                    if settings.gamingBoost {
+                                        Text("Locked to All-Intra in Gaming Boost mode")
+                                             .font(.system(size: 10))
+                                             .foregroundColor(.orange)
+                                     } else if settings.keyFrameInterval <= 1 {
+                                        Text("Every frame is independent. Higher bandwidth, no corruption from dropped frames.")
+                                             .font(.system(size: 10))
+                                             .foregroundColor(.green)
+                                     } else if settings.keyFrameInterval == 10 {
+                                        Text("Keyframe every ~0.17s. Minimal artifacts, moderate bandwidth increase.")
+                                             .font(.system(size: 10))
+                                             .foregroundColor(.green)
+                                     } else if settings.keyFrameInterval == 30 {
+                                        Text("Best balance of smoothness and bandwidth. Keyframe every ~0.5s")
+                                             .font(.system(size: 10))
+                                             .foregroundColor(.green)
+                                     } else {
+                                        Text("Maximum compression. Keyframe every ~1s. Dropped frames may cause brief artifacts.")
+                                             .font(.system(size: 10))
+                                             .foregroundColor(.green)
+                                     }
+                                }
                             }
                         }
 
@@ -497,6 +535,11 @@ struct SettingsView: View {
                                 StatusRow(title: "Accessibility", status: settings.hasAccessibilityPermission ? "Granted" : "Optional", color: settings.hasAccessibilityPermission ? .green : .orange)
                                 if settings.isRunning {
                                     StatusRow(title: "Capture Method", status: settings.captureMethod, color: settings.captureMethod.contains("fallback") ? .orange : .green)
+                                }
+
+                                if settings.isRunning {
+                                    let mode = settings.effectiveKeyFrameInterval <= 1 ? "All-Intra" : "I/P (every \(settings.effectiveKeyFrameInterval)f)"
+                                    StatusRow(title: "Encoding Mode", status: mode, color: .green)
                                 }
 
                                 if !settings.hasScreenRecordingPermission {
@@ -884,6 +927,9 @@ class DisplaySettings: ObservableObject {
     @Published var touchEnabled: Bool {
         didSet { save("touchEnabled", touchEnabled) }
     }
+    @Published var keyFrameInterval: Int {
+        didSet { save("keyFrameInterval", keyFrameInterval) }
+    }
 
     // Runtime state (not persisted)
     @Published var displayCreated = false
@@ -910,6 +956,7 @@ class DisplaySettings: ObservableObject {
         self.customWidth = defaults.object(forKey: keyPrefix + "customWidth") as? Int ?? 1920
         self.customHeight = defaults.object(forKey: keyPrefix + "customHeight") as? Int ?? 1200
         self.touchEnabled = defaults.object(forKey: keyPrefix + "touchEnabled") as? Bool ?? true
+        self.keyFrameInterval = defaults.object(forKey: keyPrefix + "keyFrameInterval") as? Int ?? 1
 
         print("Loaded settings: \(resolution) @ \(refreshRate)Hz, bitrate=\(bitrate), quality=\(quality)")
     }
@@ -966,14 +1013,18 @@ class DisplaySettings: ObservableObject {
         return gamingBoost ? 120 : refreshRate
     }
 
+    var effectiveKeyFrameInterval: Int {
+        return gamingBoost ? 1 : keyFrameInterval
+    }
+
     func toggleServer() {
         onToggleServer?()
     }
 
     func resetToDefaults() {
         let keys = ["resolution", "refreshRate", "hiDPI", "bitrate", "quality",
-                    "gamingBoost", "port", "rotation", "showAllResolutions",
-                    "customWidth", "customHeight", "touchEnabled"]
+            "gamingBoost", "port", "rotation", "showAllResolutions",
+            "customWidth", "customHeight", "touchEnabled", "keyFrameInterval"]
         for key in keys {
             defaults.removeObject(forKey: keyPrefix + key)
         }
@@ -990,6 +1041,7 @@ class DisplaySettings: ObservableObject {
         customWidth = 1920
         customHeight = 1200
         touchEnabled = true
+        keyFrameInterval = 1
 
         print("Settings reset to defaults")
     }

--- a/MacHost/Sources/SettingsWindow.swift
+++ b/MacHost/Sources/SettingsWindow.swift
@@ -490,9 +490,9 @@ struct SettingsView: View {
 
                                     Picker("", selection: $settings.keyFrameInterval) {
                                         Text("All-Intra").tag(1)
-                                        Text("Low Compression").tag(10)
-                                        Text("Balanced").tag(30)
-                                        Text("Max Compression").tag(60)
+                                        Text("Low Compression").tag(5)
+                                        Text("Balanced").tag(10)
+                                        Text("Max Compression").tag(30)
                                      }
                                      .pickerStyle(.segmented)
                                      .disabled(settings.gamingBoost)
@@ -505,18 +505,18 @@ struct SettingsView: View {
                                         Text("Every frame is independent. Higher bandwidth, no corruption from dropped frames.")
                                              .font(.system(size: 10))
                                              .foregroundColor(.green)
-                                     } else if settings.keyFrameInterval == 10 {
-                                        Text("Keyframe every ~0.17s. Minimal artifacts, moderate bandwidth increase.")
+                                     } else if settings.keyFrameInterval == 5 {
+                                        Text("Keyframe every ~0.09s. Minimal artifacts, moderate bandwidth increase.")
                                              .font(.system(size: 10))
                                              .foregroundColor(.green)
-                                     } else if settings.keyFrameInterval == 30 {
-                                        Text("Best balance of smoothness and bandwidth. Keyframe every ~0.5s")
+                                     } else if settings.keyFrameInterval == 10 {
+                                        Text("Best balance of smoothness and bandwidth. Keyframe every ~0.17s")
                                              .font(.system(size: 10))
                                              .foregroundColor(.green)
                                      } else {
-                                        Text("Maximum compression. Keyframe every ~1s. Dropped frames may cause brief artifacts.")
+                                        Text("Maximum compression. Keyframe every ~0.5s. Dropped frames may cause brief artifacts.")
                                              .font(.system(size: 10))
-                                             .foregroundColor(.green)
+                                             .foregroundColor(.orange)
                                      }
                                 }
                             }

--- a/MacHost/Sources/StreamingServer.swift
+++ b/MacHost/Sources/StreamingServer.swift
@@ -24,6 +24,7 @@ class StreamingServer {
     private var isReceiving = false
     private var isStopped = false
     private var connectionReady = false
+    private var waitingForSyncFrame = false
 
     init(port: UInt16) {
         self.port = port
@@ -74,6 +75,7 @@ class StreamingServer {
         }
 
         connectionReady = false
+        waitingForSyncFrame = true
         connection = newConnection
         droppedFrames = 0
 
@@ -84,8 +86,8 @@ class StreamingServer {
                 debugLog("Client connected - sending display config first")
                 self?.sendDisplaySize()
                 self?.connectionReady = true
-                debugLog("Connection ready for frames")
                 self?.onClientConnected?()
+                debugLog("Connection ready for frames; waiting for keyframe")
                 self?.startReceivingTouch()
             case .failed(let error):
                 debugLog("Connection failed: \(error)")
@@ -200,6 +202,14 @@ class StreamingServer {
 
     func sendFrame(_ data: Data, timestamp: UInt64, isKeyframe: Bool = false) {
         guard let connection = connection, !isStopped, connectionReady else { return }
+        if waitingForSyncFrame {
+            guard isKeyframe else {
+                droppedFrames += 1
+                return
+            }
+            waitingForSyncFrame = false
+            debugLog("First keyframe sent to new client")
+        }
 
         // With all-intra encoding, every frame is independently decodable.
         // No frame-age dropping or backpressure — send everything immediately.

--- a/MacHost/Sources/VideoEncoder.swift
+++ b/MacHost/Sources/VideoEncoder.swift
@@ -1,8 +1,13 @@
 import Foundation
 import VideoToolbox
 import CoreMedia
+import os
 
 class VideoEncoder {
+    private struct EncoderState {
+        var pendingForceKeyframe = false
+    }
+
     private var compressionSession: VTCompressionSession?
     var onEncodedFrame: ((Data, UInt64, Bool) -> Void)?  // data, timestamp, isKeyframe
     private var width: Int
@@ -11,20 +16,24 @@ class VideoEncoder {
     private var quality: String = "medium"
     private var gamingBoost: Bool = false
     private var frameRate: Int = 60
-    init(width: Int, height: Int, bitrateMbps: Int = 20, quality: String = "ultralow", gamingBoost: Bool = false, frameRate: Int = 60) {
+    private var keyFrameInterval: Int = 30
+    private let stateLock = OSAllocatedUnfairLock(initialState: EncoderState())
+    init(width: Int, height: Int, bitrateMbps: Int = 20, quality: String = "ultralow", gamingBoost: Bool = false, frameRate: Int = 60, keyFrameInterval: Int = 30) {
         self.width = width
         self.height = height
         self.bitrateMbps = gamingBoost ? 50 : bitrateMbps
         self.quality = gamingBoost ? "ultralow" : quality
         self.gamingBoost = gamingBoost
         self.frameRate = frameRate
+        self.keyFrameInterval = keyFrameInterval
         setupCompressionSession()
     }
 
-    func updateSettings(bitrateMbps: Int, quality: String, gamingBoost: Bool) {
+    func updateSettings(bitrateMbps: Int, quality: String, gamingBoost: Bool, keyFrameInterval: Int = 30) {
         self.bitrateMbps = gamingBoost ? 50 : bitrateMbps
         self.quality = gamingBoost ? "ultralow" : quality
         self.gamingBoost = gamingBoost
+        self.keyFrameInterval = keyFrameInterval
 
         // Drain pending frames before invalidation
         if let session = compressionSession {
@@ -72,11 +81,15 @@ class VideoEncoder {
         // Frame rate settings
         VTSessionSetProperty(session, key: kVTCompressionPropertyKey_ExpectedFrameRate, value: frameRate as CFNumber)
 
-        // All-intra: every frame is a keyframe
-        // Eliminates P-frame dependency → no corruption from frame loss
-        // Higher bitrate (~3x) but USB-C has plenty of bandwidth
-        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_MaxKeyFrameInterval, value: 1 as CFNumber)
-        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration, value: 0.0 as CFNumber)
+        if keyFrameInterval <= 1 {
+            // All-intra mode: every frame is a keyframe
+            VTSessionSetProperty(session, key: kVTCompressionPropertyKey_MaxKeyFrameInterval, value: 1 as CFNumber)
+            VTSessionSetProperty(session, key: kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration, value: 0.0 as CFNumber)
+        } else {
+            // Hybrid I/P mode: keyframe every N frames
+            VTSessionSetProperty(session, key: kVTCompressionPropertyKey_MaxKeyFrameInterval, value: keyFrameInterval as CFNumber)
+            VTSessionSetProperty(session, key: kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration, value: Double(keyFrameInterval) / Double(frameRate) as CFNumber)
+        }
 
         // Critical for low latency - NO frame reordering (no B-frames)
         VTSessionSetProperty(session, key: kVTCompressionPropertyKey_AllowFrameReordering, value: kCFBooleanFalse)
@@ -105,8 +118,15 @@ class VideoEncoder {
 
         VTCompressionSessionPrepareToEncodeFrames(session)
 
+        let encodingMode = keyFrameInterval <= 1 ? "ALL-INTRA" : "I/P (keyframe every \(keyFrameInterval)f)"
         let mode = gamingBoost ? "🎮 GAMING BOOST" : quality.uppercased()
-        debugLog("VideoToolbox encoder configured (H.265, \(bitrateMbps)Mbps, \(frameRate)fps, \(mode))")
+        debugLog("VideoToolbox encoder configured (H.265, \(bitrateMbps)Mbps, \(frameRate)fps, \(mode), encoding: \(encodingMode))")
+    }
+
+    /// Force the next encoded frame to be an IDR (sync) frame.
+    /// Ensures a newly connected or reinitializing decoder can start decoding immediately.
+    func requestKeyframe() {
+        stateLock.withLock { $0.pendingForceKeyframe = true }
     }
 
     func encode(pixelBuffer: CVPixelBuffer, presentationTimeStamp: CMTime) {
@@ -119,12 +139,25 @@ class VideoEncoder {
         let refconValue = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
         refconValue.storeBytes(of: captureNanos, as: UInt64.self)
 
+        let shouldForceKeyframe = stateLock.withLock { state -> Bool in
+            guard state.pendingForceKeyframe else { return false }
+            state.pendingForceKeyframe = false
+            return true
+        }
+
+        let frameProperties: CFDictionary?
+        if shouldForceKeyframe {
+            frameProperties = [kVTEncodeFrameOptionKey_ForceKeyFrame: true] as CFDictionary
+        } else {
+            frameProperties = nil
+        }
+
         VTCompressionSessionEncodeFrame(
             session,
             imageBuffer: pixelBuffer,
             presentationTimeStamp: presentationTimeStamp,
             duration: duration,
-            frameProperties: nil,
+            frameProperties: frameProperties,
             sourceFrameRefcon: refconValue,
             infoFlagsOut: nil
         )


### PR DESCRIPTION
Add new option to allow configuring frame compression. The default is the same as before "All-Intra" where every frame is a key frame. The UI allows setting how frequently to send a key frame.

I tested this with the scenario described in #13 and it seems to solve the problem, even with low compression. Durring that time I see some screen artifacts but that's a much better experience than the extreeme lag.

During normal usage, I don't notice any differences from the "All-intra"
 (no compression) option.

## Description

Brief description of the changes in this PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement

## Related Issue

Fixes #(issue number)

## Changes Made

Added support for P-Frame compression with a UI selector fro the level of compression.

## Testing

Describe how you tested your changes:

- [x] Tested on macOS 26.3.1 (25D2128) Tahoe
- [x] Tested on Android 16 on a Samsung Galaxy Tab S8 Ultra
- [x] Tested USB connection
- [x] Tested streaming performance

## Screenshots (if applicable)

Add screenshots for UI changes.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
- [x] My changes don't introduce new warnings
- [x] I have added comments for complex logic

