### PR TITLE
feat: Key frame tracking

### DIFF
--- a/AndroidClient/app/src/main/java/com/sidescreen/app/DiagLog.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/DiagLog.kt
@@ -3,6 +3,7 @@ package com.sidescreen.app
 import android.content.Context
 import android.util.Log
 import java.io.File
+import java.util.concurrent.Executors
 
 /**
  * Shared diagnostic file logger for debugging on devices that suppress logcat.
@@ -16,6 +17,13 @@ object DiagLog {
     @Volatile
     private var logFile: File? = null
 
+    private val logExecutor =
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "DiagLogWriter").apply {
+                isDaemon = true
+            }
+        }
+
     /** Initialize with app context. Call once from Application.onCreate() or MainActivity. */
     fun init(context: Context) {
         logFile = File(context.filesDir, LOG_FILE)
@@ -27,15 +35,17 @@ object DiagLog {
     ) {
         Log.d(tag, msg)
         val f = logFile ?: return
-        try {
-            // Rotate if too large
-            if (f.exists() && f.length() > MAX_LOG_SIZE) {
-                val backup = File(f.parent, "diag.log.old")
-                backup.delete()
-                f.renameTo(backup)
+        logExecutor.execute {
+            try {
+                // Rotate if too large
+                if (f.exists() && f.length() > MAX_LOG_SIZE) {
+                    val backup = File(f.parent, "diag.log.old")
+                    backup.delete()
+                    f.renameTo(backup)
+                }
+                f.appendText("[${System.currentTimeMillis()}] $tag: $msg\n")
+            } catch (_: Exception) {
             }
-            f.appendText("[${System.currentTimeMillis()}] $tag: $msg\n")
-        } catch (_: Exception) {
         }
     }
 }

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
@@ -805,10 +805,10 @@ class MainActivity : AppCompatActivity() {
      * Wire up all StreamClient callbacks. Used by both USB connect() and wireless connectWireless().
      */
     private fun setupStreamClientCallbacks() {
-        streamClient?.onFrameReceived = { frameData, frameSize, timestamp ->
+        streamClient?.onFrameReceived = { frameData, frameSize, timestamp, isKeyframe ->
             val dec = videoDecoder
             if (dec != null) {
-                dec.decode(frameData, frameSize, timestamp)
+                dec.decode(frameData, frameSize, timestamp, isKeyframe)
             } else {
                 mainDiag("FRAME DROPPED: videoDecoder is null!")
             }

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
@@ -789,6 +789,10 @@ class MainActivity : AppCompatActivity() {
             videoDecoder?.onFrameDecoded = { buffer ->
                 streamClient?.releaseBuffer(buffer)
             }
+            videoDecoder?.onKeyframeRequired = { force, reason ->
+                streamClient?.requestKeyframe(force = force, reason = reason)
+            }
+            streamClient?.requestKeyframe(force = true, reason = "decoder initialized")
             mainDiag("Decoder initialized OK ${displayWidth}x$displayHeight, videoDecoder=$videoDecoder")
             log("✅ Decoder initialized ${displayWidth}x$displayHeight (${displayObj?.refreshRate ?: 60f}Hz)")
         } catch (e: Exception) {
@@ -951,12 +955,12 @@ class MainActivity : AppCompatActivity() {
                 log("Connecting to $host:$port...")
 
                 streamClient = StreamClient(host, port)
-                streamClient?.onFrameReceived = { frameData, frameSize, timestamp ->
+                streamClient?.onFrameReceived = { frameData, frameSize, timestamp, isKeyframe ->
                     val dec = videoDecoder
                     if (dec != null) {
-                        dec.decode(frameData, frameSize, timestamp)
+                        dec.decode(frameData, frameSize, timestamp, isKeyframe)
                     } else {
-                        mainDiag("FRAME DROPPED: videoDecoder is null!")
+                        streamClient?.releaseBuffer(frameData)
                     }
                 }
 
@@ -964,6 +968,9 @@ class MainActivity : AppCompatActivity() {
                 // When decode completes, buffer is returned to StreamClient's pool
                 videoDecoder?.onFrameDecoded = { buffer ->
                     streamClient?.releaseBuffer(buffer)
+                }
+                videoDecoder?.onKeyframeRequired = { force, reason ->
+                    streamClient?.requestKeyframe(force = force, reason = reason)
                 }
 
                 // Latency measurement via ping/pong

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/StreamClient.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/StreamClient.kt
@@ -268,9 +268,13 @@ class StreamClient(
                     val type = input.readByte()
 
                     when (type.toInt()) {
-                        MESSAGE_VIDEO_FRAME -> receiveVideoFrame(input, hasMetadata = false)
+                        MESSAGE_VIDEO_FRAME -> {
+                            receiveVideoFrame(input, hasMetadata = false)
+                        }
 
-                        MESSAGE_VIDEO_FRAME_WITH_METADATA -> receiveVideoFrame(input, hasMetadata = true)
+                        MESSAGE_VIDEO_FRAME_WITH_METADATA -> {
+                            receiveVideoFrame(input, hasMetadata = true)
+                        }
 
                         1 -> { // Display size + rotation
                             val width = input.readInt()

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/StreamClient.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/StreamClient.kt
@@ -28,8 +28,9 @@ class StreamClient(
     private var outputStream: java.io.DataOutputStream? = null
     private var isConnected = false
 
-    // Callback includes actual frame size (may differ from buffer.size due to pooling) and timestamp
-    var onFrameReceived: ((ByteArray, Int, Long) -> Unit)? = null
+    // Callback includes actual frame size (may differ from buffer.size due to pooling),
+    // receive timestamp, and whether the frame can restart HEVC decoding.
+    var onFrameReceived: ((ByteArray, Int, Long, Boolean) -> Unit)? = null
     var onConnectionStatus: ((Boolean) -> Unit)? = null
     var onDisplaySize: ((Int, Int, Int) -> Unit)? = null // width, height, rotation
     var onStats: ((Double, Double) -> Unit)? = null
@@ -38,6 +39,9 @@ class StreamClient(
     private var framesReceived = 0L
     private var diagFrameCount = 0L
     private var lastStatsTime = System.currentTimeMillis()
+    private val keyframeRequestLock = Any()
+    private var lastKeyframeRequestNs = 0L
+    private var lastKeyframeReceivedNs = 0L
 
     // Buffer pooling to reduce GC pressure from per-frame allocations
     // At 60fps with ~100KB frames, this prevents ~6MB/s of allocations
@@ -81,12 +85,20 @@ class StreamClient(
     // Use THREAD_PRIORITY_DISPLAY instead of URGENT_DISPLAY to avoid starving system processes
     private val touchExecutor =
         Executors.newSingleThreadExecutor { runnable ->
-            Thread(runnable).apply {
-                name = "TouchThread"
+            Thread(
+                {
+                    // Use DISPLAY priority (less aggressive than URGENT_DISPLAY).
+                    // ThreadFactory runs on the caller thread, so set Linux priority
+                    // from inside the worker thread before processing touch writes.
+                    try {
+                        Process.setThreadPriority(Process.THREAD_PRIORITY_DISPLAY)
+                    } catch (_: Exception) {
+                    }
+                    runnable.run()
+                },
+                "TouchThread",
+            ).apply {
                 priority = Thread.MAX_PRIORITY
-                // Use DISPLAY priority (less aggressive than URGENT_DISPLAY)
-                // URGENT_DISPLAY can starve system launcher and cause lag
-                Process.setThreadPriority(Process.THREAD_PRIORITY_DISPLAY)
             }
         }
     private val touchDispatcher = touchExecutor.asCoroutineDispatcher()
@@ -102,6 +114,10 @@ class StreamClient(
                 inputStream = DataInputStream(java.io.BufferedInputStream(socket?.getInputStream(), 65536))
                 outputStream = java.io.DataOutputStream(socket?.getOutputStream())
                 isConnected = true
+                lastKeyframeReceivedNs = 0L
+                synchronized(keyframeRequestLock) {
+                    lastKeyframeRequestNs = 0L
+                }
 
                 diagLog("Connected to $host:$port")
                 onConnectionStatus?.invoke(true)
@@ -252,29 +268,9 @@ class StreamClient(
                     val type = input.readByte()
 
                     when (type.toInt()) {
-                        0 -> { // Video frame
-                            val frameSize = input.readInt()
+                        MESSAGE_VIDEO_FRAME -> receiveVideoFrame(input, hasMetadata = false)
 
-                            if (frameSize <= 0 || frameSize > MAX_FRAME_SIZE) {
-                                Log.e(TAG, "❌ Invalid frame size: $frameSize")
-                                break
-                            }
-
-                            val frameData = acquireBuffer(frameSize)
-                            input.readFully(frameData, 0, frameSize)
-
-                            // Capture timestamp after full frame received for accurate age tracking
-                            val receiveTimestamp = System.nanoTime()
-                            diagFrameCount++
-                            if (diagFrameCount == 1L) {
-                                diagLog("First video frame: size=$frameSize, callback=${onFrameReceived != null}")
-                            }
-                            if (diagFrameCount % 60L == 0L) {
-                                diagLog("Frames received: $diagFrameCount")
-                            }
-                            onFrameReceived?.invoke(frameData, frameSize, receiveTimestamp)
-                            updateStats(frameSize)
-                        }
+                        MESSAGE_VIDEO_FRAME_WITH_METADATA -> receiveVideoFrame(input, hasMetadata = true)
 
                         1 -> { // Display size + rotation
                             val width = input.readInt()
@@ -347,6 +343,47 @@ class StreamClient(
     var onLatencyMeasured: ((Double) -> Unit)? = null
 
     /**
+     * Ask the host to send an IDR/sync frame.
+     *
+     * Non-forced requests are rate-limited here so all callers share the same
+     * backpressure guard. Forced requests are reserved for startup and hard
+     * decoder recovery paths where waiting for the throttle would leave the
+     * client black or unsynchronized.
+     */
+    fun requestKeyframe(
+        force: Boolean = false,
+        reason: String = "client request",
+    ) {
+        if (!isConnected) return
+        val now = System.nanoTime()
+        val shouldSend =
+            synchronized(keyframeRequestLock) {
+                if (!force &&
+                    lastKeyframeRequestNs > 0L &&
+                    now - lastKeyframeRequestNs < KEYFRAME_REQUEST_INTERVAL_NS
+                ) {
+                    false
+                } else {
+                    lastKeyframeRequestNs = now
+                    true
+                }
+            }
+        if (!shouldSend) return
+
+        val flags = if (force) KEYFRAME_REQUEST_FLAG_FORCE else 0
+        diagLog("Requesting keyframe: reason=$reason, force=$force")
+        touchScope.launch {
+            try {
+                outputStream?.let { out ->
+                    out.write(byteArrayOf(MESSAGE_KEYFRAME_REQUEST.toByte(), flags.toByte()))
+                    out.flush()
+                }
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    /**
      * Send a ping to measure round-trip latency through the USB connection
      */
     fun sendPing() {
@@ -380,6 +417,73 @@ class StreamClient(
             bytesReceived = 0
             framesReceived = 0
             lastStatsTime = now
+        }
+    }
+
+    private fun receiveVideoFrame(
+        input: DataInputStream,
+        hasMetadata: Boolean,
+    ) {
+        val frameSize = input.readInt()
+
+        if (frameSize <= 0 || frameSize > MAX_FRAME_SIZE) {
+            throw IOException("Invalid frame size: $frameSize")
+        }
+
+        var isKeyframe = false
+        if (hasMetadata) {
+            val flags = input.readUnsignedByte()
+            input.readLong() // Host capture timestamp; clocks are not comparable with Android.
+            isKeyframe = (flags and FRAME_FLAG_KEYFRAME) != 0
+        }
+
+        val frameData = acquireBuffer(frameSize)
+        input.readFully(frameData, 0, frameSize)
+
+        if (!hasMetadata && !isKeyframe) {
+            isKeyframe = isHevcSyncFrame(frameData, frameSize)
+        }
+
+        // Capture timestamp after full frame received for accurate age tracking.
+        val receiveTimestamp = System.nanoTime()
+        checkKeyframeFreshness(receiveTimestamp, isKeyframe)
+        diagFrameCount++
+        if (diagFrameCount == 1L) {
+            diagLog(
+                "First video frame: size=$frameSize, keyframe=$isKeyframe, " +
+                    "metadata=$hasMetadata, callback=${onFrameReceived != null}",
+            )
+        }
+        if (diagFrameCount % 60L == 0L) {
+            diagLog("Frames received: $diagFrameCount")
+        }
+
+        val callback = onFrameReceived
+        if (callback != null) {
+            callback.invoke(frameData, frameSize, receiveTimestamp, isKeyframe)
+        } else {
+            releaseBuffer(frameData)
+        }
+        updateStats(frameSize)
+    }
+
+    private fun checkKeyframeFreshness(
+        receiveTimestamp: Long,
+        isKeyframe: Boolean,
+    ) {
+        if (isKeyframe) {
+            lastKeyframeReceivedNs = receiveTimestamp
+            return
+        }
+
+        val lastKeyframeNs = lastKeyframeReceivedNs
+        if (lastKeyframeNs <= 0L) return
+
+        val keyframeAgeNs = receiveTimestamp - lastKeyframeNs
+        if (keyframeAgeNs > KEYFRAME_STALE_INTERVAL_NS) {
+            requestKeyframe(
+                reason = "last keyframe ${keyframeAgeNs / 1_000_000L}ms ago",
+            )
         }
     }
 
@@ -421,5 +525,52 @@ class StreamClient(
     companion object {
         private const val TAG = "StreamClient"
         private const val MAX_FRAME_SIZE = 5 * 1024 * 1024 // 5MB
+        private const val KEYFRAME_REQUEST_INTERVAL_NS = 500_000_000L
+        private const val KEYFRAME_STALE_INTERVAL_NS = 1_500_000_000L
+        private const val MESSAGE_VIDEO_FRAME = 0
+        private const val MESSAGE_VIDEO_FRAME_WITH_METADATA = 6
+        private const val MESSAGE_KEYFRAME_REQUEST = 7
+        private const val FRAME_FLAG_KEYFRAME = 1
+        private const val KEYFRAME_REQUEST_FLAG_FORCE = 1
+
+        private fun isHevcSyncFrame(
+            data: ByteArray,
+            size: Int,
+        ): Boolean {
+            var i = 0
+            while (i + 5 < size) {
+                var start = -1
+                var startCodeLength = 0
+
+                while (i + 3 < size) {
+                    if (data[i] == 0.toByte() && data[i + 1] == 0.toByte()) {
+                        if (data[i + 2] == 1.toByte()) {
+                            start = i
+                            startCodeLength = 3
+                            break
+                        }
+                        if (i + 3 < size && data[i + 2] == 0.toByte() && data[i + 3] == 1.toByte()) {
+                            start = i
+                            startCodeLength = 4
+                            break
+                        }
+                    }
+                    i++
+                }
+
+                if (start < 0) return false
+
+                val nalStart = start + startCodeLength
+                if (nalStart + 1 >= size) return false
+
+                val nalType = (data[nalStart].toInt() and 0x7E) shr 1
+                if (nalType in 16..21) {
+                    return true
+                }
+
+                i = nalStart + 2
+            }
+            return false
+        }
     }
 }

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/StreamClient.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/StreamClient.kt
@@ -113,6 +113,7 @@ class StreamClient(
                     }
                 inputStream = DataInputStream(java.io.BufferedInputStream(socket?.getInputStream(), 65536))
                 outputStream = java.io.DataOutputStream(socket?.getOutputStream())
+                advertiseFrameMetadataSupport()
                 isConnected = true
                 lastKeyframeReceivedNs = 0L
                 synchronized(keyframeRequestLock) {
@@ -237,6 +238,7 @@ class StreamClient(
                 socket = s
                 inputStream = DataInputStream(java.io.BufferedInputStream(s.getInputStream(), 65536))
                 outputStream = java.io.DataOutputStream(s.getOutputStream())
+                advertiseFrameMetadataSupport()
                 isConnected = true
                 diagLog("Wireless connected to $host:$port")
                 onConnectionStatus?.invoke(true)
@@ -256,6 +258,14 @@ class StreamClient(
                 }
                 throw WirelessConnectError.ProtocolError
             }
+        }
+    }
+
+    private fun advertiseFrameMetadataSupport() {
+        outputStream?.let { out ->
+            out.writeByte(MESSAGE_CLIENT_SUPPORTS_FRAME_METADATA)
+            out.flush()
+            diagLog("Advertised frame metadata support")
         }
     }
 
@@ -534,6 +544,7 @@ class StreamClient(
         private const val MESSAGE_VIDEO_FRAME = 0
         private const val MESSAGE_VIDEO_FRAME_WITH_METADATA = 6
         private const val MESSAGE_KEYFRAME_REQUEST = 7
+        private const val MESSAGE_CLIENT_SUPPORTS_FRAME_METADATA = 8
         private const val FRAME_FLAG_KEYFRAME = 1
         private const val KEYFRAME_REQUEST_FLAG_FORCE = 1
 

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/VideoDecoder.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/VideoDecoder.kt
@@ -46,6 +46,7 @@ class VideoDecoder(
     private var currentHeight = initialHeight
 
     @Volatile private var isRunning = false
+
     @Volatile private var needsKeyframe = true
 
     private var lastKeyframeRequestNs = 0L
@@ -297,7 +298,8 @@ class VideoDecoder(
         inputFrameCount++
         if (inputFrameCount == 1L) {
             val header =
-                frameData.take(minOf(16, frameSize))
+                frameData
+                    .take(minOf(16, frameSize))
                     .joinToString(" ") { String.format("%02x", it) }
             diagLog(
                 "First frame: size=$frameSize, header=[$header], " +

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/VideoDecoder.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/VideoDecoder.kt
@@ -25,6 +25,7 @@ class VideoDecoder(
 
     private var frameCount = 0L
     private var droppedFrames = 0L
+    private var staleOutputDrops = 0L
     private var lastStatsTime = System.currentTimeMillis()
     private var inputFrameCount = 0L
     private var outputFrameCount = 0L
@@ -45,10 +46,14 @@ class VideoDecoder(
     private var currentHeight = initialHeight
 
     @Volatile private var isRunning = false
+    @Volatile private var needsKeyframe = true
+
+    private var lastKeyframeRequestNs = 0L
 
     var onFrameRendered: ((Long) -> Unit)? = null
     var onFrameStats: ((fps: Double, variance: Double) -> Unit)? = null
     var onFrameDecoded: ((ByteArray) -> Unit)? = null
+    var onKeyframeRequired: ((force: Boolean, reason: String) -> Unit)? = null
 
     // Available input buffer indices — fed by onInputBufferAvailable callback
     private val availableInputBuffers = ConcurrentLinkedQueue<Int>()
@@ -66,6 +71,7 @@ class VideoDecoder(
             currentHeight = height
             release()
             setupDecoder()
+            requestKeyframe("resolution changed", force = true)
         }
     }
 
@@ -107,6 +113,8 @@ class VideoDecoder(
                 ) {
                     diagLog("Codec error: ${e.diagnosticInfo}")
                     Log.e(TAG, "Codec error: ${e.diagnosticInfo}", e)
+                    needsKeyframe = true
+                    requestKeyframe("codec error", force = true)
                 }
 
                 override fun onOutputFormatChanged(
@@ -173,7 +181,6 @@ class VideoDecoder(
                         currentHeight,
                     )
                 codec.configure(minimalFormat, surface, null, 0)
-                configured = true
                 diagLog("Configured with minimal format")
             } catch (e: Exception) {
                 diagLog("All configure attempts failed: ${e.message}")
@@ -187,6 +194,7 @@ class VideoDecoder(
         }
 
         codec.setVideoScalingMode(MediaCodec.VIDEO_SCALING_MODE_SCALE_TO_FIT)
+        needsKeyframe = true
         isRunning = true
         codec.start()
         decoder = codec
@@ -207,8 +215,11 @@ class VideoDecoder(
     ): String? {
         try {
             val codecList = MediaCodecList(MediaCodecList.ALL_CODECS)
-            var hwDecoder: String? = null
-            var swDecoder: String? = null
+            val targetRate = displayRefreshRate.toDouble().coerceAtLeast(30.0)
+            var hwRateDecoder: String? = null
+            var hwSizeDecoder: String? = null
+            var swRateDecoder: String? = null
+            var swSizeDecoder: String? = null
 
             for (info in codecList.codecInfos) {
                 if (info.isEncoder) continue
@@ -224,27 +235,43 @@ class VideoDecoder(
                     !info.name.startsWith("c2.android.") &&
                         !info.name.startsWith("OMX.google.")
                 val supported = videoCaps.isSizeSupported(width, height)
+                val rateSupported =
+                    supported &&
+                        try {
+                            videoCaps.areSizeAndRateSupported(width, height, targetRate)
+                        } catch (_: Exception) {
+                            false
+                        }
 
                 diagLog(
                     "HEVC decoder '${info.name}': " +
                         "width=${videoCaps.supportedWidths}, " +
                         "height=${videoCaps.supportedHeights}, " +
-                        "hw=$isHardware, supports ${width}x$height=$supported",
+                        "hw=$isHardware, supports ${width}x$height=$supported, " +
+                        "supports @${"%.0f".format(targetRate)}fps=$rateSupported",
                 )
 
                 if (supported) {
-                    if (isHardware && hwDecoder == null) {
-                        hwDecoder = info.name
-                    } else if (!isHardware && swDecoder == null) {
-                        swDecoder = info.name
+                    if (isHardware && rateSupported && hwRateDecoder == null) {
+                        hwRateDecoder = info.name
+                    } else if (isHardware && hwSizeDecoder == null) {
+                        hwSizeDecoder = info.name
+                    } else if (!isHardware && rateSupported && swRateDecoder == null) {
+                        swRateDecoder = info.name
+                    } else if (!isHardware && swSizeDecoder == null) {
+                        swSizeDecoder = info.name
                     }
                 }
             }
 
-            // Prefer hardware, fall back to software
-            val chosen = hwDecoder ?: swDecoder
+            // Prefer hardware that advertises the target refresh rate, then any
+            // hardware decoder for the size, then software as a last resort.
+            val chosen = hwRateDecoder ?: hwSizeDecoder ?: swRateDecoder ?: swSizeDecoder
             if (chosen != null) {
-                diagLog("Selected decoder: $chosen (hw=${chosen == hwDecoder})")
+                diagLog(
+                    "Selected decoder: $chosen " +
+                        "(rateSupported=${chosen == hwRateDecoder || chosen == swRateDecoder})",
+                )
             } else {
                 diagLog("No decoder supports ${width}x$height — will use default")
             }
@@ -259,6 +286,7 @@ class VideoDecoder(
         frameData: ByteArray,
         frameSize: Int = frameData.size,
         frameTimestamp: Long = System.nanoTime(),
+        isKeyframe: Boolean = false,
     ) {
         if (!isRunning) {
             diagLog("decode called but isRunning=false")
@@ -273,7 +301,7 @@ class VideoDecoder(
                     .joinToString(" ") { String.format("%02x", it) }
             diagLog(
                 "First frame: size=$frameSize, header=[$header], " +
-                    "surface=$surface, valid=${surface.isValid}",
+                    "keyframe=$isKeyframe, surface=$surface, valid=${surface.isValid}",
             )
         }
         if (inputFrameCount % 60L == 0L) {
@@ -283,35 +311,97 @@ class VideoDecoder(
             )
         }
 
-        // Direct feed: grab an available input buffer and queue immediately
-        // No intermediate queue, no thread handoff — minimum latency
-        val index = availableInputBuffers.poll()
-        if (index == null) {
-            // No input buffer available — codec is busy, drop frame
-            droppedFrames++
-            if (droppedFrames <= 3L || droppedFrames % 60L == 0L) {
-                diagLog("No input buffer — dropping (total dropped: $droppedFrames)")
+        val codec =
+            decoder ?: run {
+                diagLog("decoder is null in decode()")
+                onFrameDecoded?.invoke(frameData)
+                return
             }
-            onFrameDecoded?.invoke(frameData)
+
+        if (needsKeyframe && !isKeyframe) {
+            dropFrame(
+                frameData,
+                isKeyframe,
+                "waiting for keyframe",
+                waitForKeyframe = true,
+            )
             return
         }
 
+        // Direct feed: grab an available input buffer and queue immediately.
+        val index = availableInputBuffers.poll()
+        if (index == null) {
+            dropFrame(
+                frameData,
+                isKeyframe,
+                "no input buffer",
+                waitForKeyframe = needsKeyframe || isKeyframe,
+                requestRefresh = true,
+            )
+            return
+        }
+
+        queueFrame(codec, index, frameData, frameSize, frameTimestamp, isKeyframe)
+    }
+
+    private fun queueFrame(
+        codec: MediaCodec,
+        index: Int,
+        frameData: ByteArray,
+        frameSize: Int,
+        frameTimestamp: Long,
+        isKeyframe: Boolean,
+    ) {
         try {
-            val codec =
-                decoder ?: run {
-                    diagLog("decoder is null in decode()")
-                    onFrameDecoded?.invoke(frameData)
-                    return
-                }
-            val inputBuffer = codec.getInputBuffer(index)
-            inputBuffer?.clear()
-            inputBuffer?.put(frameData, 0, frameSize)
+            val inputBuffer =
+                codec.getInputBuffer(index)
+                    ?: throw IllegalStateException("Input buffer $index is null")
+            inputBuffer.clear()
+            inputBuffer.put(frameData, 0, frameSize)
             codec.queueInputBuffer(index, 0, frameSize, frameTimestamp / 1000, 0)
+            if (isKeyframe) {
+                needsKeyframe = false
+            }
         } catch (e: Exception) {
+            needsKeyframe = true
+            requestKeyframe("queue input failed")
             Log.e(TAG, "decode direct feed error", e)
         } finally {
             onFrameDecoded?.invoke(frameData)
         }
+    }
+
+    private fun dropFrame(
+        frameData: ByteArray,
+        isKeyframe: Boolean,
+        reason: String,
+        waitForKeyframe: Boolean,
+        requestRefresh: Boolean = waitForKeyframe,
+    ) {
+        droppedFrames++
+        if (droppedFrames <= 3L || droppedFrames % 60L == 0L) {
+            diagLog("Dropping frame ($reason, keyframe=$isKeyframe, dropped=$droppedFrames)")
+        }
+        if (waitForKeyframe) {
+            needsKeyframe = true
+        }
+        if (requestRefresh) {
+            requestKeyframe(reason)
+        }
+        onFrameDecoded?.invoke(frameData)
+    }
+
+    private fun requestKeyframe(
+        reason: String,
+        force: Boolean = false,
+    ) {
+        val now = System.nanoTime()
+        if (!force && now - lastKeyframeRequestNs < KEYFRAME_REQUEST_INTERVAL_NS) {
+            return
+        }
+        lastKeyframeRequestNs = now
+        diagLog("Requesting keyframe: reason=$reason, force=$force")
+        onKeyframeRequired?.invoke(force, reason)
     }
 
     private fun handleOutputBuffer(
@@ -330,7 +420,8 @@ class VideoDecoder(
             // frame spent inside the codec's input/reorder/output queues.
             val nowNs = System.nanoTime()
             val latencyNs = nowNs - info.presentationTimeUs * 1000L
-            if (latencyNs in 0..2_000_000_000L) {
+            val hasValidLatency = latencyNs in 0..MAX_REASONABLE_LATENCY_NS
+            if (hasValidLatency) {
                 latencySumNs += latencyNs
                 latencySamples++
                 if (latencyNs > latencyMaxNs) latencyMaxNs = latencyNs
@@ -349,6 +440,26 @@ class VideoDecoder(
                 latencySamples = 0
                 latencyMaxNs = 0
             }
+
+            val shouldRender =
+                outputFrameCount == 1L ||
+                    !hasValidLatency ||
+                    latencyNs <= MAX_RENDER_LATENCY_NS
+
+            if (!shouldRender) {
+                droppedFrames++
+                staleOutputDrops++
+                if (staleOutputDrops <= 3L || staleOutputDrops % 60L == 0L) {
+                    diagLog(
+                        "Dropping stale output frame: latency=${"%.1f".format(latencyNs / 1_000_000.0)}ms, " +
+                            "staleDrops=$staleOutputDrops",
+                    )
+                }
+                codec.releaseOutputBuffer(index, false)
+                updateStats()
+                return
+            }
+
             codec.releaseOutputBuffer(index, true)
             trackFrameTiming(System.nanoTime())
             updateStats()
@@ -384,6 +495,7 @@ class VideoDecoder(
         if (elapsed >= 1000) {
             frameCount = 0
             droppedFrames = 0
+            staleOutputDrops = 0
             lastStatsTime = now
         }
     }
@@ -404,5 +516,8 @@ class VideoDecoder(
 
     companion object {
         private const val TAG = "VideoDecoder"
+        private const val KEYFRAME_REQUEST_INTERVAL_NS = 1_000_000_000L
+        private const val MAX_RENDER_LATENCY_NS = 100_000_000L
+        private const val MAX_REASONABLE_LATENCY_NS = 2_000_000_000L
     }
 }

--- a/MacHost/Sources/AppDelegate.swift
+++ b/MacHost/Sources/AppDelegate.swift
@@ -495,10 +495,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             streamingServer?.setDisplaySize(width: size.width, height: size.height, rotation: settings.rotation)
             streamingServer?.onClientConnected = { [weak self] in
                 guard let self = self else { return }
-                self.screenCapture?.requestKeyframeOrReplayCachedFrame()
+                self.screenCapture?.requestKeyframeOrReplayCachedFrame(force: true)
                 Task { @MainActor in
                     self.settings.clientConnected = true
                 }
+            }
+            streamingServer?.onKeyframeRequested = { [weak self] force in
+                self?.screenCapture?.requestKeyframeOrReplayCachedFrame(force: force)
             }
 
             streamingServer?.onClientDisconnected = { [weak self] in

--- a/MacHost/Sources/ScreenCapture.swift
+++ b/MacHost/Sources/ScreenCapture.swift
@@ -41,8 +41,10 @@ class ScreenCapture {
 
     private struct KeyframeRequestState {
         var pendingEncoderCreationRequest = false
+        var lastKeyframeOrReplayRequestNs: UInt64 = 0
     }
     private let keyframeRequestLock = OSAllocatedUnfairLock(initialState: KeyframeRequestState())
+    private static let keyframeRequestThrottleNs: UInt64 = 500_000_000
 
     // Main-thread-only state
     private var frameMonitorTimer: DispatchSourceTimer?
@@ -81,7 +83,19 @@ class ScreenCapture {
     /// the last cached frame as a forced keyframe if the display is currently
     /// idle. Without this, a client connecting during a static screen would
     /// wait up to one full GOP duration before its decoder could start.
-    func requestKeyframeOrReplayCachedFrame() {
+    func requestKeyframeOrReplayCachedFrame(force: Bool = false) {
+        let now = DispatchTime.now().uptimeNanoseconds
+        let shouldRequest = keyframeRequestLock.withLock { state -> Bool in
+            if !force,
+               state.lastKeyframeOrReplayRequestNs > 0,
+               now - state.lastKeyframeOrReplayRequestNs < Self.keyframeRequestThrottleNs {
+                return false
+            }
+            state.lastKeyframeOrReplayRequestNs = now
+            return true
+        }
+        guard shouldRequest else { return }
+
         requestKeyframe()
 
         guard let encoder, let cached = lastPixelBuffer else { return }

--- a/MacHost/Sources/StreamingServer.swift
+++ b/MacHost/Sources/StreamingServer.swift
@@ -64,7 +64,6 @@ class StreamingServer {
     private var connectionReady = false
     private var waitingForSyncFrame = false
     private var clientSupportsFrameMetadata = false
-    private var protocolStarted = false
     private var inputBuffer = Data()
 
     init(port: UInt16) {
@@ -117,7 +116,6 @@ class StreamingServer {
 
         connectionReady = false
         clientSupportsFrameMetadata = false
-        protocolStarted = false
         waitingForSyncFrame = true
         inputBuffer.removeAll(keepingCapacity: true)
         connection = newConnection
@@ -170,9 +168,8 @@ class StreamingServer {
     }
 
     private func finishProtocolStartup(on conn: NWConnection) {
-        guard connection === conn, !isStopped, !protocolStarted else { return }
+        guard connection === conn, !isStopped, !connectionReady else { return }
 
-        protocolStarted = true
         debugLog("Client connected - sending display config first")
         sendDisplaySize()
         connectionReady = true
@@ -425,27 +422,7 @@ class StreamingServer {
         frameQueue.async { [weak self] in
             guard let self = self else { return }
 
-            let packet: Data
-            if self.clientSupportsFrameMetadata {
-                var metadataPacket = Data(capacity: data.count + 14)
-                metadataPacket.append(WireMessage.videoFrameWithMetadata)
-                var frameSize = Int32(data.count).bigEndian
-                withUnsafeBytes(of: &frameSize) { metadataPacket.append(contentsOf: $0) }
-                metadataPacket.append(isKeyframe ? 1 : 0)
-                var captureTimestamp = timestamp.bigEndian
-                withUnsafeBytes(of: &captureTimestamp) { metadataPacket.append(contentsOf: $0) }
-                metadataPacket.append(data)
-                packet = metadataPacket
-            } else {
-                // Keep legacy frame type 0 for clients that do not advertise
-                // metadata support; remove after legacy clients age out.
-                var legacyPacket = Data(capacity: data.count + 5)
-                legacyPacket.append(WireMessage.legacyVideoFrame)
-                var frameSize = Int32(data.count).bigEndian
-                withUnsafeBytes(of: &frameSize) { legacyPacket.append(contentsOf: $0) }
-                legacyPacket.append(data)
-                packet = legacyPacket
-            }
+            let packet = self.makeFramePacket(data, timestamp: timestamp, isKeyframe: isKeyframe)
 
             connection.send(content: packet, completion: .contentProcessed { error in
                 if error != nil {
@@ -457,6 +434,32 @@ class StreamingServer {
             let sendAge = DispatchTime.now().uptimeNanoseconds - timestamp
             self.updateStats(bytes: data.count, frameAgeNs: sendAge)
         }
+    }
+
+    private func makeFramePacket(_ data: Data, timestamp: UInt64, isKeyframe: Bool) -> Data {
+        if clientSupportsFrameMetadata {
+            var packet = Data(capacity: data.count + 14)
+            packet.append(WireMessage.videoFrameWithMetadata)
+            appendFrameSize(data.count, to: &packet)
+            packet.append(isKeyframe ? 1 : 0)
+            var captureTimestamp = timestamp.bigEndian
+            withUnsafeBytes(of: &captureTimestamp) { packet.append(contentsOf: $0) }
+            packet.append(data)
+            return packet
+        }
+
+        // Keep legacy frame type 0 for clients that do not advertise
+        // metadata support; remove after legacy clients age out.
+        var packet = Data(capacity: data.count + 5)
+        packet.append(WireMessage.legacyVideoFrame)
+        appendFrameSize(data.count, to: &packet)
+        packet.append(data)
+        return packet
+    }
+
+    private func appendFrameSize(_ size: Int, to packet: inout Data) {
+        var frameSize = Int32(size).bigEndian
+        withUnsafeBytes(of: &frameSize) { packet.append(contentsOf: $0) }
     }
 
     // Pipeline profiling: track frame age at send time

--- a/MacHost/Sources/StreamingServer.swift
+++ b/MacHost/Sources/StreamingServer.swift
@@ -26,6 +26,7 @@ class StreamingServer {
     // Touch callback: (x1, y1, action, pointerCount, x2, y2)
     var onTouchEvent: ((Float, Float, Int, Int, Float, Float) -> Void)?
     var onStats: ((Double, Double) -> Void)?
+    var onKeyframeRequested: ((Bool) -> Void)?
     // Whether host wants to receive touch events from client. Ping/pong is
     // handled regardless. When false, incoming touch frames are dropped
     // immediately without parsing or dispatching to main queue.
@@ -51,6 +52,7 @@ class StreamingServer {
     private var isStopped = false
     private var connectionReady = false
     private var waitingForSyncFrame = false
+    private var inputBuffer = Data()
 
     init(port: UInt16) {
         self.port = port
@@ -102,6 +104,7 @@ class StreamingServer {
 
         connectionReady = false
         waitingForSyncFrame = true
+        inputBuffer.removeAll(keepingCapacity: true)
         connection = newConnection
         droppedFrames = 0
 
@@ -261,63 +264,107 @@ class StreamingServer {
             return
         }
 
-        // New format: 1 type + 1 pointerCount + N*(4x+4y) + 4 action
-        // 1 finger: 14 bytes, 2 fingers: 22 bytes
-        connection.receive(minimumIncompleteLength: 2, maximumLength: 22) { [weak self] data, _, isComplete, error in
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 256) { [weak self] data, _, isComplete, error in
             guard let self = self, self.isReceiving, !self.isStopped else { return }
 
             if error != nil || isComplete {
                 self.isReceiving = false
+                self.inputBuffer.removeAll(keepingCapacity: true)
                 return
             }
 
-            if let data = data, data.count >= 1 {
-                let msgType = data[0]
-
-                if msgType == 2 && data.count >= 2 {
-                    // Touch event — drop early if host has touch disabled,
-                    // skipping parsing and main-queue dispatch entirely.
-                    if !self.touchEnabled {
-                        self.receiveQueue.async {
-                            self.touchReceiveLoop()
-                        }
-                        return
-                    }
-                    let pointerCount = Int(data[1])
-                    let expectedSize = 2 + pointerCount * 8 + 4
-
-                    if data.count >= expectedSize {
-                        let x1 = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 2, as: Float.self) }
-                        let y1 = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 6, as: Float.self) }
-
-                        var x2: Float = 0
-                        var y2: Float = 0
-                        if pointerCount >= 2 {
-                            x2 = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 10, as: Float.self) }
-                            y2 = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 14, as: Float.self) }
-                        }
-
-                        let actionOffset = 2 + pointerCount * 8
-                        let action = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: actionOffset, as: Int32.self) }
-
-                        DispatchQueue.main.async {
-                            self.onTouchEvent?(x1, y1, Int(action), pointerCount, x2, y2)
-                        }
-                    }
-                } else if msgType == 4 && data.count >= 9 {
-                    // Ping from client — echo back as pong (type=5) with client's timestamp
-                    let clientTimestamp = data.subdata(in: 1..<9)
-                    var pong = Data(capacity: 9)
-                    pong.append(5) // Type: Pong
-                    pong.append(clientTimestamp)
-                    connection.send(content: pong, completion: .contentProcessed { _ in })
-                }
+            if let data = data, !data.isEmpty {
+                self.inputBuffer.append(data)
+                self.processInputBuffer(connection: connection)
             }
 
             self.receiveQueue.async {
                 self.touchReceiveLoop()
             }
         }
+    }
+
+    private func processInputBuffer(connection: NWConnection) {
+        while let msgType = inputBuffer.first {
+            switch msgType {
+            case 2:
+                // Touch event: 1 type + 1 pointerCount + N*(4x+4y) + 4 action.
+                // 1 finger: 14 bytes, 2 fingers: 22 bytes.
+                guard inputBuffer.count >= 2 else { return }
+
+                let pointerCount = Int(inputByte(at: 1))
+                guard pointerCount == 1 || pointerCount == 2 else {
+                    debugLog("Invalid touch pointer count: \(pointerCount)")
+                    consumeInputBytes(1)
+                    continue
+                }
+
+                let expectedSize = 2 + pointerCount * 8 + 4
+                guard inputBuffer.count >= expectedSize else { return }
+
+                let message = Data(inputBuffer.prefix(expectedSize))
+                consumeInputBytes(expectedSize)
+
+                // Drop early if host has touch disabled, after consuming exactly
+                // this touch frame so coalesced ping/keyframe messages survive.
+                if touchEnabled {
+                    handleTouchMessage(message, pointerCount: pointerCount)
+                }
+
+            case 4:
+                // Ping from client: echo back as pong (type=5) with client's timestamp.
+                guard inputBuffer.count >= 9 else { return }
+
+                let clientTimestamp = Data(inputBuffer.dropFirst().prefix(8))
+                consumeInputBytes(9)
+
+                var pong = Data(capacity: 9)
+                pong.append(5) // Type: Pong
+                pong.append(clientTimestamp)
+                connection.send(content: pong, completion: .contentProcessed { _ in })
+
+            case 7:
+                // Keyframe request from Android decoder. The client sends a
+                // two-byte message: type + flags.
+                guard inputBuffer.count >= 2 else { return }
+
+                let flags = inputByte(at: 1)
+                consumeInputBytes(2)
+                onKeyframeRequested?((flags & 1) != 0)
+
+            default:
+                debugLog("Unknown client input type: \(msgType)")
+                consumeInputBytes(1)
+            }
+        }
+    }
+
+    private func handleTouchMessage(_ data: Data, pointerCount: Int) {
+        let x1 = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 2, as: Float.self) }
+        let y1 = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 6, as: Float.self) }
+
+        var x2: Float = 0
+        var y2: Float = 0
+        if pointerCount >= 2 {
+            x2 = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 10, as: Float.self) }
+            y2 = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 14, as: Float.self) }
+        }
+
+        let actionOffset = 2 + pointerCount * 8
+        let action = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: actionOffset, as: Int32.self) }
+
+        DispatchQueue.main.async {
+            self.onTouchEvent?(x1, y1, Int(action), pointerCount, x2, y2)
+        }
+    }
+
+    private func inputByte(at offset: Int) -> UInt8 {
+        inputBuffer[inputBuffer.index(inputBuffer.startIndex, offsetBy: offset)]
+    }
+
+    private func consumeInputBytes(_ count: Int) {
+        let endIndex = inputBuffer.index(inputBuffer.startIndex, offsetBy: count)
+        inputBuffer.removeSubrange(inputBuffer.startIndex..<endIndex)
     }
 
     func sendFrame(_ data: Data, timestamp: UInt64, isKeyframe: Bool = false) {
@@ -339,10 +386,13 @@ class StreamingServer {
         frameQueue.async { [weak self] in
             guard let self = self else { return }
 
-            var packet = Data(capacity: data.count + 5)
-            packet.append(0) // Type: Video frame
+            var packet = Data(capacity: data.count + 14)
+            packet.append(6) // Type: Video frame with metadata
             var frameSize = Int32(data.count).bigEndian
             withUnsafeBytes(of: &frameSize) { packet.append(contentsOf: $0) }
+            packet.append(isKeyframe ? 1 : 0)
+            var captureTimestamp = timestamp.bigEndian
+            withUnsafeBytes(of: &captureTimestamp) { packet.append(contentsOf: $0) }
             packet.append(data)
 
             connection.send(content: packet, completion: .contentProcessed { error in

--- a/MacHost/Sources/StreamingServer.swift
+++ b/MacHost/Sources/StreamingServer.swift
@@ -1,6 +1,17 @@
 import Foundation
 import Network
 
+private enum WireMessage {
+    static let legacyVideoFrame: UInt8 = 0
+    static let displayConfig: UInt8 = 1
+    static let touchEvent: UInt8 = 2
+    static let ping: UInt8 = 4
+    static let pong: UInt8 = 5
+    static let videoFrameWithMetadata: UInt8 = 6
+    static let keyframeRequest: UInt8 = 7
+    static let clientSupportsFrameMetadata: UInt8 = 8
+}
+
 private extension NWEndpoint {
     var isLoopback: Bool {
         switch self {
@@ -52,6 +63,8 @@ class StreamingServer {
     private var isStopped = false
     private var connectionReady = false
     private var waitingForSyncFrame = false
+    private var clientSupportsFrameMetadata = false
+    private var protocolStarted = false
     private var inputBuffer = Data()
 
     init(port: UInt16) {
@@ -103,6 +116,8 @@ class StreamingServer {
         }
 
         connectionReady = false
+        clientSupportsFrameMetadata = false
+        protocolStarted = false
         waitingForSyncFrame = true
         inputBuffer.removeAll(keepingCapacity: true)
         connection = newConnection
@@ -143,12 +158,26 @@ class StreamingServer {
     }
 
     private func beginExistingProtocol(on conn: NWConnection) {
+        startReceivingTouch()
+
+        // Give new clients a short chance to opt in before the first frame.
+        // Legacy clients send no capability message, so we continue shortly
+        // after this window with the old frame type.
+        networkQueue.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self, weak conn] in
+            guard let self = self, let conn = conn else { return }
+            self.finishProtocolStartup(on: conn)
+        }
+    }
+
+    private func finishProtocolStartup(on conn: NWConnection) {
+        guard connection === conn, !isStopped, !protocolStarted else { return }
+
+        protocolStarted = true
         debugLog("Client connected - sending display config first")
         sendDisplaySize()
         connectionReady = true
-        debugLog("Connection ready for frames")
+        debugLog("Connection ready for frames (metadata=\(clientSupportsFrameMetadata ? "on" : "off"))")
         onClientConnected?()
-        startReceivingTouch()
     }
 
     private func runAuthHandshake(connection conn: NWConnection, expectedToken: Data) {
@@ -235,7 +264,7 @@ class StreamingServer {
         guard let connection = connection else { return }
 
         var data = Data()
-        data.append(1) // Type: Display size + rotation
+        data.append(WireMessage.displayConfig) // Type: Display size + rotation
         data.append(contentsOf: withUnsafeBytes(of: Int32(displayWidth).bigEndian) { Data($0) })
         data.append(contentsOf: withUnsafeBytes(of: Int32(displayHeight).bigEndian) { Data($0) })
         data.append(contentsOf: withUnsafeBytes(of: Int32(rotation).bigEndian) { Data($0) })
@@ -287,7 +316,7 @@ class StreamingServer {
     private func processInputBuffer(connection: NWConnection) {
         while let msgType = inputBuffer.first {
             switch msgType {
-            case 2:
+            case WireMessage.touchEvent:
                 // Touch event: 1 type + 1 pointerCount + N*(4x+4y) + 4 action.
                 // 1 finger: 14 bytes, 2 fingers: 22 bytes.
                 guard inputBuffer.count >= 2 else { return }
@@ -311,7 +340,7 @@ class StreamingServer {
                     handleTouchMessage(message, pointerCount: pointerCount)
                 }
 
-            case 4:
+            case WireMessage.ping:
                 // Ping from client: echo back as pong (type=5) with client's timestamp.
                 guard inputBuffer.count >= 9 else { return }
 
@@ -319,11 +348,11 @@ class StreamingServer {
                 consumeInputBytes(9)
 
                 var pong = Data(capacity: 9)
-                pong.append(5) // Type: Pong
+                pong.append(WireMessage.pong) // Type: Pong
                 pong.append(clientTimestamp)
                 connection.send(content: pong, completion: .contentProcessed { _ in })
 
-            case 7:
+            case WireMessage.keyframeRequest:
                 // Keyframe request from Android decoder. The client sends a
                 // two-byte message: type + flags.
                 guard inputBuffer.count >= 2 else { return }
@@ -331,6 +360,16 @@ class StreamingServer {
                 let flags = inputByte(at: 1)
                 consumeInputBytes(2)
                 onKeyframeRequested?((flags & 1) != 0)
+
+            case WireMessage.clientSupportsFrameMetadata:
+                // One-byte opt-in from newer clients. Keeping this payload-free
+                // lets older hosts safely ignore it without misaligning input.
+                consumeInputBytes(1)
+                if !clientSupportsFrameMetadata {
+                    clientSupportsFrameMetadata = true
+                    debugLog("Client supports video frame metadata")
+                }
+                finishProtocolStartup(on: connection)
 
             default:
                 debugLog("Unknown client input type: \(msgType)")
@@ -386,14 +425,27 @@ class StreamingServer {
         frameQueue.async { [weak self] in
             guard let self = self else { return }
 
-            var packet = Data(capacity: data.count + 14)
-            packet.append(6) // Type: Video frame with metadata
-            var frameSize = Int32(data.count).bigEndian
-            withUnsafeBytes(of: &frameSize) { packet.append(contentsOf: $0) }
-            packet.append(isKeyframe ? 1 : 0)
-            var captureTimestamp = timestamp.bigEndian
-            withUnsafeBytes(of: &captureTimestamp) { packet.append(contentsOf: $0) }
-            packet.append(data)
+            let packet: Data
+            if self.clientSupportsFrameMetadata {
+                var metadataPacket = Data(capacity: data.count + 14)
+                metadataPacket.append(WireMessage.videoFrameWithMetadata)
+                var frameSize = Int32(data.count).bigEndian
+                withUnsafeBytes(of: &frameSize) { metadataPacket.append(contentsOf: $0) }
+                metadataPacket.append(isKeyframe ? 1 : 0)
+                var captureTimestamp = timestamp.bigEndian
+                withUnsafeBytes(of: &captureTimestamp) { metadataPacket.append(contentsOf: $0) }
+                metadataPacket.append(data)
+                packet = metadataPacket
+            } else {
+                // Keep legacy frame type 0 for clients that do not advertise
+                // metadata support; remove after legacy clients age out.
+                var legacyPacket = Data(capacity: data.count + 5)
+                legacyPacket.append(WireMessage.legacyVideoFrame)
+                var frameSize = Int32(data.count).bigEndian
+                withUnsafeBytes(of: &frameSize) { legacyPacket.append(contentsOf: $0) }
+                legacyPacket.append(data)
+                packet = legacyPacket
+            }
 
             connection.send(content: packet, completion: .contentProcessed { error in
                 if error != nil {

--- a/MacHost/StreamTest/Sources/TestServer.swift
+++ b/MacHost/StreamTest/Sources/TestServer.swift
@@ -82,6 +82,7 @@ class TestServer {
             case .failed, .cancelled:
                 print("[INFO] Client disconnected")
                 self?.isClientConnected = false
+                self?.clientConnectedCallbackSent = false
                 self?.isReceiving = false
                 self?.inputBuffer.removeAll(keepingCapacity: true)
                 self?.onClientDisconnected?()
@@ -93,9 +94,9 @@ class TestServer {
 
     private func finishClientStartup(on conn: NWConnection) {
         guard connection === conn, isClientConnected, !clientConnectedCallbackSent else { return }
-        clientConnectedCallbackSent = true
         print("[OK] Frame metadata: \(clientSupportsFrameMetadata ? "enabled" : "legacy")")
         onClientConnected?()
+        clientConnectedCallbackSent = true
     }
 
     private func startReceivingInput(on conn: NWConnection) {
@@ -185,10 +186,11 @@ class TestServer {
 
     /// Send a video frame (same protocol as SideScreen)
     func sendFrame(_ data: Data, isKeyframe: Bool) {
-        guard let connection = connection, isClientConnected else { return }
+        guard let connection = connection, isClientConnected, clientConnectedCallbackSent else { return }
 
         sendQueue.async { [weak self] in
             guard let self = self else { return }
+            guard self.isClientConnected, self.clientConnectedCallbackSent else { return }
 
             // Simple backpressure - but NEVER drop keyframes
             if !isKeyframe && !self.canSendNext {

--- a/MacHost/StreamTest/Sources/TestServer.swift
+++ b/MacHost/StreamTest/Sources/TestServer.swift
@@ -4,9 +4,7 @@ import Network
 /// Minimal TCP server that matches SideScreen's protocol exactly
 /// Protocol:
 ///   Display config: [type=1][width:4B BE][height:4B BE][rotation:4B BE]
-///   Video frame:    [type=0][size:4B BE][H.265 data]
 ///   Video metadata: [type=6][size:4B BE][flags:1B][timestamp:8B BE][H.265 data]
-///   Client opt-in:  [type=8]
 class TestServer {
     private let port: UInt16
     private var listener: NWListener?
@@ -21,10 +19,6 @@ class TestServer {
     private var bytesSent: UInt64 = 0
     private var framesDropped: UInt64 = 0
     private var canSendNext = true
-    private var isReceiving = false
-    private var clientSupportsFrameMetadata = false
-    private var clientConnectedCallbackSent = false
-    private var inputBuffer = Data()
 
     init(port: UInt16) {
         self.port = port
@@ -64,27 +58,16 @@ class TestServer {
         framesSent = 0
         bytesSent = 0
         framesDropped = 0
-        isReceiving = false
-        clientSupportsFrameMetadata = false
-        clientConnectedCallbackSent = false
-        inputBuffer.removeAll(keepingCapacity: true)
+        isClientConnected = false
 
         newConnection.stateUpdateHandler = { [weak self] state in
             switch state {
             case .ready:
                 print("[OK] Client connected!")
-                self?.isClientConnected = true
-                self?.startReceivingInput(on: newConnection)
-                self?.networkQueue.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self, weak newConnection] in
-                    guard let self = self, let newConnection = newConnection else { return }
-                    self.finishClientStartup(on: newConnection)
-                }
+                self?.finishClientStartup(on: newConnection)
             case .failed, .cancelled:
                 print("[INFO] Client disconnected")
                 self?.isClientConnected = false
-                self?.clientConnectedCallbackSent = false
-                self?.isReceiving = false
-                self?.inputBuffer.removeAll(keepingCapacity: true)
                 self?.onClientDisconnected?()
             default: break
             }
@@ -93,83 +76,10 @@ class TestServer {
     }
 
     private func finishClientStartup(on conn: NWConnection) {
-        guard connection === conn, isClientConnected, !clientConnectedCallbackSent else { return }
-        print("[OK] Frame metadata: \(clientSupportsFrameMetadata ? "enabled" : "legacy")")
+        guard connection === conn, !isClientConnected else { return }
+        print("[OK] Frame metadata: enabled")
         onClientConnected?()
-        clientConnectedCallbackSent = true
-    }
-
-    private func startReceivingInput(on conn: NWConnection) {
-        guard !isReceiving else { return }
-        isReceiving = true
-        receiveInput(on: conn)
-    }
-
-    private func receiveInput(on conn: NWConnection) {
-        guard connection === conn, isReceiving else { return }
-        conn.receive(minimumIncompleteLength: 1, maximumLength: 256) { [weak self, weak conn] data, _, isComplete, error in
-            guard let self = self, let conn = conn, self.connection === conn, self.isReceiving else { return }
-            if error != nil || isComplete {
-                self.isReceiving = false
-                self.inputBuffer.removeAll(keepingCapacity: true)
-                return
-            }
-            if let data = data, !data.isEmpty {
-                self.inputBuffer.append(data)
-                self.processInputBuffer(connection: conn)
-            }
-            self.receiveInput(on: conn)
-        }
-    }
-
-    private func processInputBuffer(connection: NWConnection) {
-        while let msgType = inputBuffer.first {
-            switch msgType {
-            case 2:
-                guard inputBuffer.count >= 2 else { return }
-                let pointerCount = Int(inputByte(at: 1))
-                guard pointerCount == 1 || pointerCount == 2 else {
-                    consumeInputBytes(1)
-                    continue
-                }
-                let expectedSize = 2 + pointerCount * 8 + 4
-                guard inputBuffer.count >= expectedSize else { return }
-                consumeInputBytes(expectedSize)
-
-            case 4:
-                guard inputBuffer.count >= 9 else { return }
-                let clientTimestamp = Data(inputBuffer.dropFirst().prefix(8))
-                consumeInputBytes(9)
-                var pong = Data(capacity: 9)
-                pong.append(5)
-                pong.append(clientTimestamp)
-                connection.send(content: pong, completion: .contentProcessed { _ in })
-
-            case 7:
-                guard inputBuffer.count >= 2 else { return }
-                consumeInputBytes(2)
-
-            case 8:
-                consumeInputBytes(1)
-                if !clientSupportsFrameMetadata {
-                    clientSupportsFrameMetadata = true
-                    print("[OK] Client supports frame metadata")
-                }
-                finishClientStartup(on: connection)
-
-            default:
-                consumeInputBytes(1)
-            }
-        }
-    }
-
-    private func inputByte(at offset: Int) -> UInt8 {
-        inputBuffer[inputBuffer.index(inputBuffer.startIndex, offsetBy: offset)]
-    }
-
-    private func consumeInputBytes(_ count: Int) {
-        let endIndex = inputBuffer.index(inputBuffer.startIndex, offsetBy: count)
-        inputBuffer.removeSubrange(inputBuffer.startIndex..<endIndex)
+        isClientConnected = true
     }
 
     /// Send display size config (must be sent before frames)
@@ -186,11 +96,11 @@ class TestServer {
 
     /// Send a video frame (same protocol as SideScreen)
     func sendFrame(_ data: Data, isKeyframe: Bool) {
-        guard let connection = connection, isClientConnected, clientConnectedCallbackSent else { return }
+        guard let connection = connection, isClientConnected else { return }
 
         sendQueue.async { [weak self] in
             guard let self = self else { return }
-            guard self.isClientConnected, self.clientConnectedCallbackSent else { return }
+            guard self.isClientConnected else { return }
 
             // Simple backpressure - but NEVER drop keyframes
             if !isKeyframe && !self.canSendNext {
@@ -198,27 +108,7 @@ class TestServer {
                 return
             }
 
-            let packet: Data
-            if self.clientSupportsFrameMetadata {
-                var metadataPacket = Data(capacity: data.count + 14)
-                metadataPacket.append(6)  // type = video frame with metadata
-                var frameSize = Int32(data.count).bigEndian
-                withUnsafeBytes(of: &frameSize) { metadataPacket.append(contentsOf: $0) }
-                metadataPacket.append(isKeyframe ? 1 : 0)
-                var timestamp = DispatchTime.now().uptimeNanoseconds.bigEndian
-                withUnsafeBytes(of: &timestamp) { metadataPacket.append(contentsOf: $0) }
-                metadataPacket.append(data)
-                packet = metadataPacket
-            } else {
-                // TODO: Keep legacy frame type 0 for clients that do not advertise
-                // metadata support; remove after legacy clients age out.
-                var legacyPacket = Data(capacity: data.count + 5)
-                legacyPacket.append(0)  // type = legacy video frame
-                var frameSize = Int32(data.count).bigEndian
-                withUnsafeBytes(of: &frameSize) { legacyPacket.append(contentsOf: $0) }
-                legacyPacket.append(data)
-                packet = legacyPacket
-            }
+            let packet = self.makeFramePacket(data, isKeyframe: isKeyframe)
 
             self.canSendNext = false
             connection.send(content: packet, completion: .contentProcessed { [weak self] error in
@@ -240,8 +130,23 @@ class TestServer {
     }
 
     func stop() {
-        isReceiving = false
         connection?.cancel()
         listener?.cancel()
+    }
+
+    private func makeFramePacket(_ data: Data, isKeyframe: Bool) -> Data {
+        var packet = Data(capacity: data.count + 14)
+        packet.append(6)  // type = video frame with metadata
+        appendFrameSize(data.count, to: &packet)
+        packet.append(isKeyframe ? 1 : 0)
+        var timestamp = DispatchTime.now().uptimeNanoseconds.bigEndian
+        withUnsafeBytes(of: &timestamp) { packet.append(contentsOf: $0) }
+        packet.append(data)
+        return packet
+    }
+
+    private func appendFrameSize(_ size: Int, to packet: inout Data) {
+        var frameSize = Int32(size).bigEndian
+        withUnsafeBytes(of: &frameSize) { packet.append(contentsOf: $0) }
     }
 }

--- a/MacHost/StreamTest/Sources/TestServer.swift
+++ b/MacHost/StreamTest/Sources/TestServer.swift
@@ -5,6 +5,8 @@ import Network
 /// Protocol:
 ///   Display config: [type=1][width:4B BE][height:4B BE][rotation:4B BE]
 ///   Video frame:    [type=0][size:4B BE][H.265 data]
+///   Video metadata: [type=6][size:4B BE][flags:1B][timestamp:8B BE][H.265 data]
+///   Client opt-in:  [type=8]
 class TestServer {
     private let port: UInt16
     private var listener: NWListener?
@@ -19,6 +21,10 @@ class TestServer {
     private var bytesSent: UInt64 = 0
     private var framesDropped: UInt64 = 0
     private var canSendNext = true
+    private var isReceiving = false
+    private var clientSupportsFrameMetadata = false
+    private var clientConnectedCallbackSent = false
+    private var inputBuffer = Data()
 
     init(port: UInt16) {
         self.port = port
@@ -58,21 +64,111 @@ class TestServer {
         framesSent = 0
         bytesSent = 0
         framesDropped = 0
+        isReceiving = false
+        clientSupportsFrameMetadata = false
+        clientConnectedCallbackSent = false
+        inputBuffer.removeAll(keepingCapacity: true)
 
         newConnection.stateUpdateHandler = { [weak self] state in
             switch state {
             case .ready:
                 print("[OK] Client connected!")
                 self?.isClientConnected = true
-                self?.onClientConnected?()
+                self?.startReceivingInput(on: newConnection)
+                self?.networkQueue.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self, weak newConnection] in
+                    guard let self = self, let newConnection = newConnection else { return }
+                    self.finishClientStartup(on: newConnection)
+                }
             case .failed, .cancelled:
                 print("[INFO] Client disconnected")
                 self?.isClientConnected = false
+                self?.isReceiving = false
+                self?.inputBuffer.removeAll(keepingCapacity: true)
                 self?.onClientDisconnected?()
             default: break
             }
         }
         newConnection.start(queue: networkQueue)
+    }
+
+    private func finishClientStartup(on conn: NWConnection) {
+        guard connection === conn, isClientConnected, !clientConnectedCallbackSent else { return }
+        clientConnectedCallbackSent = true
+        print("[OK] Frame metadata: \(clientSupportsFrameMetadata ? "enabled" : "legacy")")
+        onClientConnected?()
+    }
+
+    private func startReceivingInput(on conn: NWConnection) {
+        guard !isReceiving else { return }
+        isReceiving = true
+        receiveInput(on: conn)
+    }
+
+    private func receiveInput(on conn: NWConnection) {
+        guard connection === conn, isReceiving else { return }
+        conn.receive(minimumIncompleteLength: 1, maximumLength: 256) { [weak self, weak conn] data, _, isComplete, error in
+            guard let self = self, let conn = conn, self.connection === conn, self.isReceiving else { return }
+            if error != nil || isComplete {
+                self.isReceiving = false
+                self.inputBuffer.removeAll(keepingCapacity: true)
+                return
+            }
+            if let data = data, !data.isEmpty {
+                self.inputBuffer.append(data)
+                self.processInputBuffer(connection: conn)
+            }
+            self.receiveInput(on: conn)
+        }
+    }
+
+    private func processInputBuffer(connection: NWConnection) {
+        while let msgType = inputBuffer.first {
+            switch msgType {
+            case 2:
+                guard inputBuffer.count >= 2 else { return }
+                let pointerCount = Int(inputByte(at: 1))
+                guard pointerCount == 1 || pointerCount == 2 else {
+                    consumeInputBytes(1)
+                    continue
+                }
+                let expectedSize = 2 + pointerCount * 8 + 4
+                guard inputBuffer.count >= expectedSize else { return }
+                consumeInputBytes(expectedSize)
+
+            case 4:
+                guard inputBuffer.count >= 9 else { return }
+                let clientTimestamp = Data(inputBuffer.dropFirst().prefix(8))
+                consumeInputBytes(9)
+                var pong = Data(capacity: 9)
+                pong.append(5)
+                pong.append(clientTimestamp)
+                connection.send(content: pong, completion: .contentProcessed { _ in })
+
+            case 7:
+                guard inputBuffer.count >= 2 else { return }
+                consumeInputBytes(2)
+
+            case 8:
+                consumeInputBytes(1)
+                if !clientSupportsFrameMetadata {
+                    clientSupportsFrameMetadata = true
+                    print("[OK] Client supports frame metadata")
+                }
+                finishClientStartup(on: connection)
+
+            default:
+                consumeInputBytes(1)
+            }
+        }
+    }
+
+    private func inputByte(at offset: Int) -> UInt8 {
+        inputBuffer[inputBuffer.index(inputBuffer.startIndex, offsetBy: offset)]
+    }
+
+    private func consumeInputBytes(_ count: Int) {
+        let endIndex = inputBuffer.index(inputBuffer.startIndex, offsetBy: count)
+        inputBuffer.removeSubrange(inputBuffer.startIndex..<endIndex)
     }
 
     /// Send display size config (must be sent before frames)
@@ -100,14 +196,27 @@ class TestServer {
                 return
             }
 
-            var packet = Data(capacity: data.count + 14)
-            packet.append(6)  // type = video frame with metadata
-            var frameSize = Int32(data.count).bigEndian
-            withUnsafeBytes(of: &frameSize) { packet.append(contentsOf: $0) }
-            packet.append(isKeyframe ? 1 : 0)
-            var timestamp = DispatchTime.now().uptimeNanoseconds.bigEndian
-            withUnsafeBytes(of: &timestamp) { packet.append(contentsOf: $0) }
-            packet.append(data)
+            let packet: Data
+            if self.clientSupportsFrameMetadata {
+                var metadataPacket = Data(capacity: data.count + 14)
+                metadataPacket.append(6)  // type = video frame with metadata
+                var frameSize = Int32(data.count).bigEndian
+                withUnsafeBytes(of: &frameSize) { metadataPacket.append(contentsOf: $0) }
+                metadataPacket.append(isKeyframe ? 1 : 0)
+                var timestamp = DispatchTime.now().uptimeNanoseconds.bigEndian
+                withUnsafeBytes(of: &timestamp) { metadataPacket.append(contentsOf: $0) }
+                metadataPacket.append(data)
+                packet = metadataPacket
+            } else {
+                // TODO: Keep legacy frame type 0 for clients that do not advertise
+                // metadata support; remove after legacy clients age out.
+                var legacyPacket = Data(capacity: data.count + 5)
+                legacyPacket.append(0)  // type = legacy video frame
+                var frameSize = Int32(data.count).bigEndian
+                withUnsafeBytes(of: &frameSize) { legacyPacket.append(contentsOf: $0) }
+                legacyPacket.append(data)
+                packet = legacyPacket
+            }
 
             self.canSendNext = false
             connection.send(content: packet, completion: .contentProcessed { [weak self] error in
@@ -129,6 +238,7 @@ class TestServer {
     }
 
     func stop() {
+        isReceiving = false
         connection?.cancel()
         listener?.cancel()
     }

--- a/MacHost/StreamTest/Sources/TestServer.swift
+++ b/MacHost/StreamTest/Sources/TestServer.swift
@@ -100,10 +100,13 @@ class TestServer {
                 return
             }
 
-            var packet = Data(capacity: data.count + 5)
-            packet.append(0)  // type = video frame
+            var packet = Data(capacity: data.count + 14)
+            packet.append(6)  // type = video frame with metadata
             var frameSize = Int32(data.count).bigEndian
             withUnsafeBytes(of: &frameSize) { packet.append(contentsOf: $0) }
+            packet.append(isKeyframe ? 1 : 0)
+            var timestamp = DispatchTime.now().uptimeNanoseconds.bigEndian
+            withUnsafeBytes(of: &timestamp) { packet.append(contentsOf: $0) }
             packet.append(data)
 
             self.canSendNext = false


### PR DESCRIPTION
These changes add key frame aware stream recovery between the Android client and Mac host for a smoother experience under load.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
   - not breaking because it explicitly adds backwards compatibility but updated host and client are needed to get the benefits from the change. 
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement

## Related Issue

Relates to #13 

## Changes Made

  - Android now parses video-frame metadata, tracks whether frames are keyframes, and can request a fresh keyframe from the host when startup, decoder errors, stale keyframes, or dropped sync require it.
  - The decoder now waits for a keyframe before feeding frames after startup/recovery, drops unsyncable or stale frames, and requests forced keyframes on resolution changes and codec errors.
  - The Mac host now sends video packets with metadata, including keyframe flag and capture timestamp, and handles a new Android-to-host keyframe request message.
  - ScreenCapture now throttles non-forced keyframe/replay requests, while allowing forced requests for startup/recovery.
  - The host input parser was made buffered, so coalesced touch, ping, and keyframe messages are handled correctly.
  - Smaller supporting changes: async diagnostic file logging, safer buffer release when no decoder exists, corrected touch-thread priority setup, and the stream test server now emits the new metadata packet format.


## Testing

Describe how you tested your changes:

- [x] Tested on macOS 26.3.1 (25D2128) Tahoe
- [x] Tested on Android 16 on a Samsung Galaxy Tab S8 Ultra
- [x] Tested USB connection
- [x] Tested streaming performance

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes thoroughly
- [ ] I have updated documentation if needed
- [x] My changes don't introduce new warnings
- [x] I have added comments for complex logic
