### PR TITLE
fix: disable TCP Fast Open to fix wireless connection failures

### DIFF
--- a/MacHost/Sources/StreamingServer.swift
+++ b/MacHost/Sources/StreamingServer.swift
@@ -91,7 +91,6 @@ class StreamingServer {
             // Optimize TCP for low-latency streaming
             if let tcpOptions = params.defaultProtocolStack.transportProtocol as? NWProtocolTCP.Options {
                 tcpOptions.noDelay = true  // Disable Nagle's algorithm
-                tcpOptions.enableFastOpen = true
             }
 
             listener = try NWListener(using: params, on: NWEndpoint.Port(integerLiteral: port))


### PR DESCRIPTION
## Problem

Wireless connection fails on many networks (mobile hotspots, carrier NAT). The Android client connects at TCP level but the Mac never responds — connection stays in `.preparing` state indefinitely, then Android times out with \"Couldn't reach Mac\".

## Root Cause

`tcpOptions.enableFastOpen = true` in `StreamingServer.swift` causes Apple's NW Framework to hold `NWConnection` in `.preparing` until TFO data arrives in the SYN packet. Android's `java.net.Socket` uses standard TCP (no TFO), so no data ever arrives in the SYN → connection never transitions to `.ready` → `onConnectionReady` never fires → auth handshake never runs.

This was confirmed via `/tmp/sidescreen.log` showing every wireless attempt as:
```
New connection incoming...
Connection state: preparing
Connection state: cancelled   ← times out, never .ready
```

And via `tcpdump` showing TCP 3-way handshake completing at kernel level, auth data arriving from Android, but Mac never sending application-layer response.

## Fix

Remove `tcpOptions.enableFastOpen = true`. One line deletion. `noDelay` (Nagle disabled) is kept — that's the relevant low-latency optimization.

## Testing

Confirmed by community member in issue #10 — removing this line fixes wireless connection immediately on Samsung S10+ and OnePlus Nord 5 across multiple network types.

Closes #10