### PR TITLE
perf(android): release dropped wireless frame buffers

### DIFF
--- a/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
@@ -835,6 +835,7 @@ class MainActivity : AppCompatActivity() {
                 dec.decode(frameData, frameSize, timestamp, isKeyframe)
             } else {
                 mainDiag("FRAME DROPPED: videoDecoder is null!")
+                streamClient?.releaseBuffer(frameData)
             }
         }
 


### PR DESCRIPTION
## Summary
- Return pooled frame buffers when wireless frames arrive before the decoder is ready
- Matches the existing USB dropped-frame behavior
- Reduces avoidable allocation/GC pressure during startup or surface transitions

## Verification
- env -u ANDROID_SDK_ROOT ./gradlew testDebugUnitTest lintDebug
  - Unit tests passed
  - lintDebug failed on pre-existing MissingConstraints errors in activity_main.xml