### PR TITLE
Add stylus pressure, tilt, and hover support

### DIFF
--- a/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
@@ -39,6 +39,14 @@ import java.net.Socket
 
 private fun mainDiag(msg: String) = DiagLog.log("MA", msg)
 
+private const val TOUCH_ACTION_DOWN = 0
+private const val TOUCH_ACTION_MOVE = 1
+private const val TOUCH_ACTION_UP = 2
+private const val TOUCH_ACTION_HOVER = 3
+private const val TOUCH_ACTION_HOVER_EXIT = 4
+private const val TOUCH_FLAG_STYLUS = 1
+private const val TOUCH_FLAG_HOVER = 1 shl 1
+
 class MainActivity : AppCompatActivity() {
     private lateinit var wirelessController: WirelessTabController
     private val pairedHostStorage by lazy { PairedHostStorage(this) }
@@ -314,6 +322,9 @@ class MainActivity : AppCompatActivity() {
         binding.surfaceView.setOnTouchListener { view, event ->
             handleTouch(view, event)
             true
+        }
+        binding.surfaceView.setOnHoverListener { view, event ->
+            handleStylusHover(view, event)
         }
     }
 
@@ -1186,6 +1197,12 @@ class MainActivity : AppCompatActivity() {
         val x = event.x / view.width.toFloat()
         val y = event.y / view.height.toFloat()
         val pointerCount = event.pointerCount.coerceAtMost(2)
+        val primaryPointerIndex = 0
+        val isStylus =
+            event.getToolType(primaryPointerIndex) == MotionEvent.TOOL_TYPE_STYLUS
+        val pressure = if (isStylus) event.getPressure(primaryPointerIndex) else 0f
+        val tilt = if (isStylus) event.getAxisValue(MotionEvent.AXIS_TILT, primaryPointerIndex) else 0f
+        val flags = if (isStylus) TOUCH_FLAG_STYLUS else 0
 
         var x2 = 0f
         var y2 = 0f
@@ -1198,37 +1215,81 @@ class MainActivity : AppCompatActivity() {
             MotionEvent.ACTION_DOWN -> {
                 inputPredictor.reset()
                 inputPredictor.addSample(x, y)
-                streamClient?.sendTouch(x, y, 0, pointerCount, x2, y2)
+                streamClient?.sendTouch(x, y, TOUCH_ACTION_DOWN, pointerCount, x2, y2, pressure, tilt, flags)
             }
 
             MotionEvent.ACTION_POINTER_DOWN -> {
-                streamClient?.sendTouch(x, y, 0, pointerCount, x2, y2)
+                streamClient?.sendTouch(x, y, TOUCH_ACTION_DOWN, pointerCount, x2, y2, pressure, tilt, flags)
             }
 
             MotionEvent.ACTION_MOVE -> {
-                if (pointerCount == 1) {
+                if (pointerCount == 1 && !isStylus) {
                     inputPredictor.addSample(x, y)
                     val (px, py) = inputPredictor.predictPosition(12f)
                     streamClient?.sendTouch(px, py, 1, 1)
                 } else {
-                    streamClient?.sendTouch(x, y, 1, pointerCount, x2, y2)
+                    streamClient?.sendTouch(x, y, TOUCH_ACTION_MOVE, pointerCount, x2, y2, pressure, tilt, flags)
                 }
             }
 
             MotionEvent.ACTION_UP -> {
                 inputPredictor.reset()
-                streamClient?.sendTouch(x, y, 2, 1)
+                streamClient?.sendTouch(x, y, TOUCH_ACTION_UP, 1, pressure = pressure, tilt = tilt, flags = flags)
             }
 
             MotionEvent.ACTION_POINTER_UP -> {
-                streamClient?.sendTouch(x, y, 2, pointerCount, x2, y2)
+                streamClient?.sendTouch(x, y, TOUCH_ACTION_UP, pointerCount, x2, y2, pressure, tilt, flags)
             }
 
             MotionEvent.ACTION_CANCEL -> {
                 inputPredictor.reset()
-                streamClient?.sendTouch(x, y, 2, 1)
+                streamClient?.sendTouch(x, y, TOUCH_ACTION_UP, 1, pressure = pressure, tilt = tilt, flags = flags)
             }
         }
+    }
+
+    private fun handleStylusHover(
+        view: View,
+        event: MotionEvent,
+    ): Boolean {
+        val pointerIndex = 0
+        if (event.getToolType(pointerIndex) != MotionEvent.TOOL_TYPE_STYLUS) {
+            return false
+        }
+
+        val x = (event.x / view.width.toFloat()).coerceIn(0f, 1f)
+        val y = (event.y / view.height.toFloat()).coerceIn(0f, 1f)
+        val tilt = event.getAxisValue(MotionEvent.AXIS_TILT, pointerIndex)
+        val flags = TOUCH_FLAG_STYLUS or TOUCH_FLAG_HOVER
+
+        when (event.actionMasked) {
+            MotionEvent.ACTION_HOVER_ENTER,
+            MotionEvent.ACTION_HOVER_MOVE -> {
+                streamClient?.sendTouch(
+                    x,
+                    y,
+                    TOUCH_ACTION_HOVER,
+                    pressure = 0f,
+                    tilt = tilt,
+                    flags = flags,
+                )
+                return true
+            }
+
+            MotionEvent.ACTION_HOVER_EXIT -> {
+                streamClient?.sendTouch(
+                    x,
+                    y,
+                    TOUCH_ACTION_HOVER_EXIT,
+                    pressure = 0f,
+                    tilt = tilt,
+                    flags = flags,
+                )
+                return true
+            }
+        }
+
+        return false
     }
 
     /**

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
@@ -1219,14 +1219,28 @@ class MainActivity : AppCompatActivity() {
         val primaryPointerIndex = fingerPointers[0]
         val x = event.getX(primaryPointerIndex) / view.width.toFloat()
         val y = event.getY(primaryPointerIndex) / view.height.toFloat()
-        val pointerCount = fingerPointers.size.coerceAtMost(2)
+        val pointerCount = fingerPointers.size.coerceAtMost(4)
 
         var x2 = 0f
         var y2 = 0f
+        var x3 = 0f
+        var y3 = 0f
+        var x4 = 0f
+        var y4 = 0f
         if (pointerCount >= 2) {
             val secondPointerIndex = fingerPointers[1]
             x2 = event.getX(secondPointerIndex) / view.width.toFloat()
             y2 = event.getY(secondPointerIndex) / view.height.toFloat()
+        }
+        if (pointerCount >= 3) {
+            val thirdPointerIndex = fingerPointers[2]
+            x3 = event.getX(thirdPointerIndex) / view.width.toFloat()
+            y3 = event.getY(thirdPointerIndex) / view.height.toFloat()
+        }
+        if (pointerCount >= 4) {
+            val fourthPointerIndex = fingerPointers[3]
+            x4 = event.getX(fourthPointerIndex) / view.width.toFloat()
+            y4 = event.getY(fourthPointerIndex) / view.height.toFloat()
         }
 
         when (event.actionMasked) {
@@ -1235,13 +1249,13 @@ class MainActivity : AppCompatActivity() {
                 inputPredictor.addSample(x, y)
                 activeFingerTouch = true
                 rememberFingerPosition(x, y)
-                streamClient?.sendTouch(x, y, TOUCH_ACTION_DOWN, pointerCount, x2, y2)
+                streamClient?.sendTouch(x, y, TOUCH_ACTION_DOWN, pointerCount, x2, y2, x3, y3, x4, y4)
             }
 
             MotionEvent.ACTION_POINTER_DOWN -> {
                 activeFingerTouch = true
                 rememberFingerPosition(x, y)
-                streamClient?.sendTouch(x, y, TOUCH_ACTION_DOWN, pointerCount, x2, y2)
+                streamClient?.sendTouch(x, y, TOUCH_ACTION_DOWN, pointerCount, x2, y2, x3, y3, x4, y4)
             }
 
             MotionEvent.ACTION_MOVE -> {
@@ -1252,7 +1266,7 @@ class MainActivity : AppCompatActivity() {
                     streamClient?.sendTouch(px, py, TOUCH_ACTION_MOVE, 1)
                 } else {
                     rememberFingerPosition(x, y)
-                    streamClient?.sendTouch(x, y, TOUCH_ACTION_MOVE, pointerCount, x2, y2)
+                    streamClient?.sendTouch(x, y, TOUCH_ACTION_MOVE, pointerCount, x2, y2, x3, y3, x4, y4)
                 }
             }
 
@@ -1265,7 +1279,7 @@ class MainActivity : AppCompatActivity() {
 
             MotionEvent.ACTION_POINTER_UP -> {
                 rememberFingerPosition(x, y)
-                streamClient?.sendTouch(x, y, TOUCH_ACTION_UP, pointerCount, x2, y2)
+                streamClient?.sendTouch(x, y, TOUCH_ACTION_UP, pointerCount, x2, y2, x3, y3, x4, y4)
             }
 
             MotionEvent.ACTION_CANCEL -> {
@@ -1434,7 +1448,7 @@ class MainActivity : AppCompatActivity() {
                 event.eventTime - lastStylusEventTimeMs in 0..PALM_REJECT_AFTER_STYLUS_MS
         if (recentlyUsedStylus) return true
 
-        if (event.pointerCount > 2) return true
+        if (event.pointerCount > 4) return true
 
         val minDimension = minOf(view.width, view.height).coerceAtLeast(1).toFloat()
         return (0 until event.pointerCount).any { pointerIndex ->

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
@@ -46,6 +46,10 @@ private const val TOUCH_ACTION_HOVER = 3
 private const val TOUCH_ACTION_HOVER_EXIT = 4
 private const val TOUCH_FLAG_STYLUS = 1
 private const val TOUCH_FLAG_HOVER = 1 shl 1
+private const val PALM_REJECT_AFTER_STYLUS_MS = 500L
+private const val PALM_TOUCH_MAJOR_RATIO = 0.08f
+private const val PALM_TOOL_MAJOR_RATIO = 0.12f
+private const val PALM_SIZE_THRESHOLD = 0.45f
 
 class MainActivity : AppCompatActivity() {
     private lateinit var wirelessController: WirelessTabController
@@ -69,6 +73,11 @@ class MainActivity : AppCompatActivity() {
 
     // Input prediction for low-latency gaming
     private val inputPredictor = InputPredictor()
+    private var lastStylusEventTimeMs = 0L
+    private var rejectingPalmTouch = false
+    private var activeFingerTouch = false
+    private var lastFingerX = 0f
+    private var lastFingerY = 0f
 
     // Checklist status handler
     private val checklistHandler = Handler(Looper.getMainLooper())
@@ -1194,56 +1203,146 @@ class MainActivity : AppCompatActivity() {
         view: View,
         event: MotionEvent,
     ) {
-        val x = event.x / view.width.toFloat()
-        val y = event.y / view.height.toFloat()
-        val pointerCount = event.pointerCount.coerceAtMost(2)
-        val primaryPointerIndex = 0
-        val isStylus =
-            event.getToolType(primaryPointerIndex) == MotionEvent.TOOL_TYPE_STYLUS
-        val pressure = if (isStylus) event.getPressure(primaryPointerIndex) else 0f
-        val tilt = if (isStylus) event.getAxisValue(MotionEvent.AXIS_TILT, primaryPointerIndex) else 0f
-        val flags = if (isStylus) TOUCH_FLAG_STYLUS else 0
+        findStylusPointerIndex(event)?.let { stylusPointerIndex ->
+            handleStylusTouch(view, event, stylusPointerIndex)
+            return
+        }
+
+        if (shouldRejectPalmTouch(view, event)) {
+            rejectPalmTouch(event)
+            return
+        }
+
+        val fingerPointers = collectFingerPointerIndices(event)
+        if (fingerPointers.isEmpty()) return
+
+        val primaryPointerIndex = fingerPointers[0]
+        val x = event.getX(primaryPointerIndex) / view.width.toFloat()
+        val y = event.getY(primaryPointerIndex) / view.height.toFloat()
+        val pointerCount = fingerPointers.size.coerceAtMost(2)
 
         var x2 = 0f
         var y2 = 0f
         if (pointerCount >= 2) {
-            x2 = event.getX(1) / view.width.toFloat()
-            y2 = event.getY(1) / view.height.toFloat()
+            val secondPointerIndex = fingerPointers[1]
+            x2 = event.getX(secondPointerIndex) / view.width.toFloat()
+            y2 = event.getY(secondPointerIndex) / view.height.toFloat()
         }
 
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 inputPredictor.reset()
                 inputPredictor.addSample(x, y)
-                streamClient?.sendTouch(x, y, TOUCH_ACTION_DOWN, pointerCount, x2, y2, pressure, tilt, flags)
+                activeFingerTouch = true
+                rememberFingerPosition(x, y)
+                streamClient?.sendTouch(x, y, TOUCH_ACTION_DOWN, pointerCount, x2, y2)
             }
 
             MotionEvent.ACTION_POINTER_DOWN -> {
-                streamClient?.sendTouch(x, y, TOUCH_ACTION_DOWN, pointerCount, x2, y2, pressure, tilt, flags)
+                activeFingerTouch = true
+                rememberFingerPosition(x, y)
+                streamClient?.sendTouch(x, y, TOUCH_ACTION_DOWN, pointerCount, x2, y2)
             }
 
             MotionEvent.ACTION_MOVE -> {
-                if (pointerCount == 1 && !isStylus) {
+                if (pointerCount == 1) {
                     inputPredictor.addSample(x, y)
                     val (px, py) = inputPredictor.predictPosition(12f)
-                    streamClient?.sendTouch(px, py, 1, 1)
+                    rememberFingerPosition(px, py)
+                    streamClient?.sendTouch(px, py, TOUCH_ACTION_MOVE, 1)
                 } else {
-                    streamClient?.sendTouch(x, y, TOUCH_ACTION_MOVE, pointerCount, x2, y2, pressure, tilt, flags)
+                    rememberFingerPosition(x, y)
+                    streamClient?.sendTouch(x, y, TOUCH_ACTION_MOVE, pointerCount, x2, y2)
                 }
             }
 
             MotionEvent.ACTION_UP -> {
                 inputPredictor.reset()
-                streamClient?.sendTouch(x, y, TOUCH_ACTION_UP, 1, pressure = pressure, tilt = tilt, flags = flags)
+                activeFingerTouch = false
+                rememberFingerPosition(x, y)
+                streamClient?.sendTouch(x, y, TOUCH_ACTION_UP, 1)
             }
 
             MotionEvent.ACTION_POINTER_UP -> {
-                streamClient?.sendTouch(x, y, TOUCH_ACTION_UP, pointerCount, x2, y2, pressure, tilt, flags)
+                rememberFingerPosition(x, y)
+                streamClient?.sendTouch(x, y, TOUCH_ACTION_UP, pointerCount, x2, y2)
             }
 
             MotionEvent.ACTION_CANCEL -> {
                 inputPredictor.reset()
-                streamClient?.sendTouch(x, y, TOUCH_ACTION_UP, 1, pressure = pressure, tilt = tilt, flags = flags)
+                activeFingerTouch = false
+                streamClient?.sendTouch(lastFingerX, lastFingerY, TOUCH_ACTION_UP, 1)
+            }
+        }
+    }
+
+    private fun handleStylusTouch(
+        view: View,
+        event: MotionEvent,
+        pointerIndex: Int,
+    ) {
+        lastStylusEventTimeMs = event.eventTime
+        rejectingPalmTouch = false
+        if (activeFingerTouch) {
+            inputPredictor.reset()
+            activeFingerTouch = false
+            streamClient?.sendTouch(lastFingerX, lastFingerY, TOUCH_ACTION_UP, 1)
+        }
+
+        val x = event.getX(pointerIndex) / view.width.toFloat()
+        val y = event.getY(pointerIndex) / view.height.toFloat()
+        val pressure = event.getPressure(pointerIndex)
+        val tilt = event.getAxisValue(MotionEvent.AXIS_TILT, pointerIndex)
+
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN,
+            MotionEvent.ACTION_POINTER_DOWN -> {
+                if (event.actionIndex == pointerIndex || event.actionMasked == MotionEvent.ACTION_DOWN) {
+                    streamClient?.sendTouch(
+                        x,
+                        y,
+                        TOUCH_ACTION_DOWN,
+                        pressure = pressure,
+                        tilt = tilt,
+                        flags = TOUCH_FLAG_STYLUS,
+                    )
+                }
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                streamClient?.sendTouch(
+                    x,
+                    y,
+                    TOUCH_ACTION_MOVE,
+                    pressure = pressure,
+                    tilt = tilt,
+                    flags = TOUCH_FLAG_STYLUS,
+                )
+            }
+
+            MotionEvent.ACTION_UP,
+            MotionEvent.ACTION_CANCEL -> {
+                streamClient?.sendTouch(
+                    x,
+                    y,
+                    TOUCH_ACTION_UP,
+                    pressure = pressure,
+                    tilt = tilt,
+                    flags = TOUCH_FLAG_STYLUS,
+                )
+            }
+
+            MotionEvent.ACTION_POINTER_UP -> {
+                if (event.actionIndex == pointerIndex) {
+                    streamClient?.sendTouch(
+                        x,
+                        y,
+                        TOUCH_ACTION_UP,
+                        pressure = pressure,
+                        tilt = tilt,
+                        flags = TOUCH_FLAG_STYLUS,
+                    )
+                }
             }
         }
     }
@@ -1257,6 +1356,7 @@ class MainActivity : AppCompatActivity() {
             return false
         }
 
+        lastStylusEventTimeMs = event.eventTime
         val x = (event.x / view.width.toFloat()).coerceIn(0f, 1f)
         val y = (event.y / view.height.toFloat()).coerceIn(0f, 1f)
         val tilt = event.getAxisValue(MotionEvent.AXIS_TILT, pointerIndex)
@@ -1290,6 +1390,79 @@ class MainActivity : AppCompatActivity() {
         }
 
         return false
+    }
+
+    private fun rememberFingerPosition(
+        x: Float,
+        y: Float,
+    ) {
+        lastFingerX = x
+        lastFingerY = y
+    }
+
+    private fun collectFingerPointerIndices(event: MotionEvent): List<Int> =
+        (0 until event.pointerCount).filter { pointerIndex ->
+            when (event.getToolType(pointerIndex)) {
+                MotionEvent.TOOL_TYPE_FINGER,
+                MotionEvent.TOOL_TYPE_UNKNOWN -> true
+                else -> false
+            }
+        }
+
+    private fun findStylusPointerIndex(event: MotionEvent): Int? =
+        (0 until event.pointerCount).firstOrNull { pointerIndex ->
+            when (event.getToolType(pointerIndex)) {
+                MotionEvent.TOOL_TYPE_STYLUS,
+                MotionEvent.TOOL_TYPE_ERASER -> true
+                else -> false
+            }
+        }
+
+    private fun shouldRejectPalmTouch(
+        view: View,
+        event: MotionEvent,
+    ): Boolean {
+        if (event.actionMasked == MotionEvent.ACTION_UP || event.actionMasked == MotionEvent.ACTION_CANCEL) {
+            rejectingPalmTouch = false
+            return false
+        }
+
+        if (rejectingPalmTouch) return true
+
+        val recentlyUsedStylus =
+            lastStylusEventTimeMs > 0 &&
+                event.eventTime - lastStylusEventTimeMs in 0..PALM_REJECT_AFTER_STYLUS_MS
+        if (recentlyUsedStylus) return true
+
+        if (event.pointerCount > 2) return true
+
+        val minDimension = minOf(view.width, view.height).coerceAtLeast(1).toFloat()
+        return (0 until event.pointerCount).any { pointerIndex ->
+            val toolType = event.getToolType(pointerIndex)
+            val isFingerLike =
+                toolType == MotionEvent.TOOL_TYPE_FINGER ||
+                    toolType == MotionEvent.TOOL_TYPE_UNKNOWN
+            if (!isFingerLike) return@any true
+
+            val touchMajorRatio = event.getTouchMajor(pointerIndex) / minDimension
+            val toolMajorRatio = event.getToolMajor(pointerIndex) / minDimension
+            val size = event.getSize(pointerIndex)
+            touchMajorRatio >= PALM_TOUCH_MAJOR_RATIO ||
+                toolMajorRatio >= PALM_TOOL_MAJOR_RATIO ||
+                size >= PALM_SIZE_THRESHOLD
+        }
+    }
+
+    private fun rejectPalmTouch(event: MotionEvent) {
+        if (activeFingerTouch) {
+            inputPredictor.reset()
+            activeFingerTouch = false
+            streamClient?.sendTouch(lastFingerX, lastFingerY, TOUCH_ACTION_UP, 1)
+        }
+
+        rejectingPalmTouch =
+            event.actionMasked != MotionEvent.ACTION_UP &&
+            event.actionMasked != MotionEvent.ACTION_CANCEL
     }
 
     /**

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/StreamClient.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/StreamClient.kt
@@ -361,6 +361,9 @@ class StreamClient(
         pointerCount: Int = 1,
         x2: Float = 0f,
         y2: Float = 0f,
+        pressure: Float = 0f,
+        tilt: Float = 0f,
+        flags: Int = 0,
     ) {
         if (!isConnected) return
 
@@ -368,7 +371,8 @@ class StreamClient(
             try {
                 socket?.getOutputStream()?.let { out ->
                     val count = pointerCount.coerceIn(1, 2)
-                    val size = 6 + count * 8 // 1 type + 1 count + N*(4x+4y) + 4 action
+                    // 1 type + 1 count + N*(4x+4y) + 4 action + 4 pressure + 4 tilt + 4 flags
+                    val size = 18 + count * 8
                     val buffer = ByteBuffer.allocate(size).order(ByteOrder.LITTLE_ENDIAN)
                     buffer.put(2.toByte())
                     buffer.put(count.toByte())
@@ -379,6 +383,9 @@ class StreamClient(
                         buffer.putFloat(y2)
                     }
                     buffer.putInt(action)
+                    buffer.putFloat(pressure)
+                    buffer.putFloat(tilt)
+                    buffer.putInt(flags)
                     out.write(buffer.array())
                     out.flush()
                 }

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/StreamClient.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/StreamClient.kt
@@ -361,6 +361,10 @@ class StreamClient(
         pointerCount: Int = 1,
         x2: Float = 0f,
         y2: Float = 0f,
+        x3: Float = 0f,
+        y3: Float = 0f,
+        x4: Float = 0f,
+        y4: Float = 0f,
         pressure: Float = 0f,
         tilt: Float = 0f,
         flags: Int = 0,
@@ -370,7 +374,7 @@ class StreamClient(
         touchScope.launch {
             try {
                 socket?.getOutputStream()?.let { out ->
-                    val count = pointerCount.coerceIn(1, 2)
+                    val count = pointerCount.coerceIn(1, 4)
                     // 1 type + 1 count + N*(4x+4y) + 4 action + 4 pressure + 4 tilt + 4 flags
                     val size = 18 + count * 8
                     val buffer = ByteBuffer.allocate(size).order(ByteOrder.LITTLE_ENDIAN)
@@ -378,9 +382,17 @@ class StreamClient(
                     buffer.put(count.toByte())
                     buffer.putFloat(x)
                     buffer.putFloat(y)
-                    if (count == 2) {
+                    if (count >= 2) {
                         buffer.putFloat(x2)
                         buffer.putFloat(y2)
+                    }
+                    if (count >= 3) {
+                        buffer.putFloat(x3)
+                        buffer.putFloat(y3)
+                    }
+                    if (count >= 4) {
+                        buffer.putFloat(x4)
+                        buffer.putFloat(y4)
                     }
                     buffer.putInt(action)
                     buffer.putFloat(pressure)

--- a/MacHost/Sources/AppDelegate.swift
+++ b/MacHost/Sources/AppDelegate.swift
@@ -34,6 +34,19 @@ enum GestureState {
     case pinching         // Pinch zoom
 }
 
+private enum TouchAction {
+    static let down = 0
+    static let move = 1
+    static let up = 2
+    static let hover = 3
+    static let hoverExit = 4
+}
+
+private enum TouchFlags {
+    static let stylus = 1
+    static let hover = 1 << 1
+}
+
 struct GestureThresholds {
     static let tapMaxDistance: CGFloat = 15
     static let tapMaxTime: UInt64 = 250_000_000       // 250ms
@@ -98,6 +111,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         settings.adbInstalled = StatusDetector.adbInstalled()
         settings.wifiConnected = StatusDetector.wifiReachable()
         settings.listeningAddress = LANAddressResolver.primaryIPv4()
+        settings.hasAccessibilityPermission = AXIsProcessTrusted()
 
         // While a wireless client is actively streaming, keep its lastConnected
         // rolling forward so the UI shows "just now". On disconnect, the
@@ -554,8 +568,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
 
-            streamingServer?.onTouchEvent = { [weak self] x, y, action, pointerCount, x2, y2 in
-                self?.handleTouch(x: x, y: y, action: action, pointerCount: pointerCount, x2: x2, y2: y2)
+            streamingServer?.onTouchEvent = { [weak self] x, y, action, pointerCount, x2, y2, pressure, tilt, flags in
+                self?.handleTouch(x: x, y: y, action: action, pointerCount: pointerCount, x2: x2, y2: y2, pressure: pressure, tilt: tilt, flags: flags)
             }
 
             streamingServer?.onStats = { [weak self] fps, mbps in
@@ -646,13 +660,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Touch Entry Point
 
-    func handleTouch(x: Float, y: Float, action: Int, pointerCount: Int = 1, x2: Float = 0, y2: Float = 0) {
+    func handleTouch(x: Float, y: Float, action: Int, pointerCount: Int = 1, x2: Float = 0, y2: Float = 0, pressure: Float = 0, tilt: Float = 0, flags: Int = 0) {
         guard settings.touchEnabled else { return }
 
         if !AXIsProcessTrusted() {
             if !accessibilityWarningShown {
                 accessibilityWarningShown = true
-                print("⚠️  Accessibility not granted - touch ignored")
+                debugLog("Accessibility not granted - touch ignored")
                 Task { @MainActor in
                     settings.hasAccessibilityPermission = false
                 }
@@ -672,7 +686,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             y: bounds.origin.y + CGFloat(y2) * bounds.height
         )
 
-        if pointerCount >= 2 {
+        let isStylus = (flags & TouchFlags.stylus) != 0
+        if isStylus {
+            injectTabletEvent(at: p1, action: action, pressure: pressure, tilt: tilt)
+        } else if pointerCount >= 2 {
             handleTwoFingerTouch(p1: p1, p2: p2, action: action)
         } else {
             handleOneFingerTouch(at: p1, action: action)
@@ -884,6 +901,35 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if let event = CGEvent(mouseEventSource: eventSource, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left) {
             event.post(tap: .cghidEventTap)
         }
+    }
+
+    private func injectTabletEvent(at point: CGPoint, action: Int, pressure: Float, tilt: Float) {
+        let eventType: CGEventType
+        switch action {
+        case TouchAction.down:
+            eventType = .leftMouseDown
+        case TouchAction.move:
+            eventType = .leftMouseDragged
+        case TouchAction.up:
+            eventType = .leftMouseUp
+        case TouchAction.hover, TouchAction.hoverExit:
+            eventType = .mouseMoved
+        default:
+            return
+        }
+
+        guard let event = CGEvent(
+            mouseEventSource: eventSource,
+            mouseType: eventType,
+            mouseCursorPosition: point,
+            mouseButton: .left
+        ) else { return }
+
+        event.setIntegerValueField(.mouseEventSubtype, value: Int64(NX_SUBTYPE_TABLET_POINT))
+        event.setDoubleValueField(.tabletEventPointPressure, value: Double(pressure))
+        event.setDoubleValueField(.tabletEventTiltX, value: Double(tilt))
+        event.setDoubleValueField(.tabletEventTiltY, value: 0)
+        event.post(tap: .cghidEventTap)
     }
 
     private func performClick(at point: CGPoint) {

--- a/MacHost/Sources/AppDelegate.swift
+++ b/MacHost/Sources/AppDelegate.swift
@@ -55,8 +55,13 @@ struct GestureThresholds {
     static let doubleTapMaxDistance: CGFloat = 20
     static let longPressTime: UInt64 = 500_000_000     // 500ms
     static let scrollSensitivity: CGFloat = 1.2
-    static let pinchMinDistance: CGFloat = 20
-    static let pinchSensitivity: CGFloat = 1.2
+    static let pinchMinDistance: CGFloat = 28
+    static let pinchDominanceRatio: CGFloat = 1.15
+    static let scrollToPinchMinDistance: CGFloat = 48
+    static let scrollToPinchDominanceRatio: CGFloat = 1.8
+    static let pinchShortcutStepDistance: CGFloat = 55
+    static let pinchShortcutInterval: UInt64 = 90_000_000 // ~11Hz
+    static let pinchDirectionResetDistance: CGFloat = 24
     static let minScrollDelta: CGFloat = 0.5
     static let minPinchDelta: CGFloat = 1.0
     static let multiFingerSwipeMinDistance: CGFloat = 70
@@ -657,6 +662,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // 2-finger tracking
     private var initialPinchDistance: CGFloat = 0
     private var lastPinchDistance: CGFloat = 0
+    private var pinchShortcutRemainder: CGFloat = 0
+    private var lastPinchShortcutTime: UInt64 = 0
+    private var lastPinchDirection: Int = 0
+    private var lastTwoFingerDebugTime: UInt64 = 0
     private var multiFingerStartPosition: CGPoint = .zero
     private var multiFingerLastPosition: CGPoint = .zero
     private var multiFingerCount = 0
@@ -930,17 +939,35 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             gestureState = .idle
             initialPinchDistance = distance
             lastPinchDistance = distance
+            pinchShortcutRemainder = 0
+            lastPinchShortcutTime = 0
+            lastPinchDirection = 0
+            touchStartPosition = midpoint
             touchLastPosition = midpoint
 
         case 1: // Move
+            let now = DispatchTime.now().uptimeNanoseconds
             let rawDX = midpoint.x - touchLastPosition.x
             let rawDY = midpoint.y - touchLastPosition.y
-            let didScroll = abs(rawDX) >= GestureThresholds.minScrollDelta || abs(rawDY) >= GestureThresholds.minScrollDelta
             let totalPinchDelta = distance - initialPinchDistance
-            let pendingPinchDelta = distance - lastPinchDistance
-            let didPinch =
-                abs(totalPinchDelta) >= GestureThresholds.pinchMinDistance &&
-                abs(pendingPinchDelta) >= GestureThresholds.minPinchDelta
+            let framePinchDelta = distance - lastPinchDistance
+            let panDistance = hypot(midpoint.x - touchStartPosition.x, midpoint.y - touchStartPosition.y)
+            let canPromoteScrollToPinch =
+                gestureState == .twoFingerScroll &&
+                abs(totalPinchDelta) >= GestureThresholds.scrollToPinchMinDistance &&
+                abs(totalPinchDelta) > panDistance * GestureThresholds.scrollToPinchDominanceRatio
+            let shouldPinch =
+                gestureState == .pinching ||
+                canPromoteScrollToPinch ||
+                (
+                    gestureState != .twoFingerScroll &&
+                    abs(totalPinchDelta) >= GestureThresholds.pinchMinDistance &&
+                    abs(totalPinchDelta) > panDistance * GestureThresholds.pinchDominanceRatio
+                )
+            let didScroll =
+                !shouldPinch &&
+                gestureState != .pinching &&
+                (abs(rawDX) >= GestureThresholds.minScrollDelta || abs(rawDY) >= GestureThresholds.minScrollDelta)
 
             if didScroll {
                 let phase: CGScrollPhase = gestureState == .idle ? .began : .changed
@@ -954,26 +981,40 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
 
-            if didPinch {
-                let zoomAmount = Int32((pendingPinchDelta * GestureThresholds.pinchSensitivity).rounded())
-                if zoomAmount != 0 {
-                    injectZoomEvent(delta: zoomAmount, at: midpoint)
-                    gestureState = .pinching
-                    lastPinchDistance = distance
+            if shouldPinch && gestureState != .pinching {
+                if gestureState == .twoFingerScroll {
+                    injectScrollEvent(deltaX: 0, deltaY: 0, at: midpoint, phase: .ended)
                 }
+                gestureState = .pinching
+                lastPinchDistance = distance
+                pinchShortcutRemainder = 0
+                lastPinchShortcutTime = 0
+                lastPinchDirection = 0
+                debugLog("Two-finger pinch began: initial=\(String(format: "%.1f", initialPinchDistance)) current=\(String(format: "%.1f", distance)) totalDelta=\(String(format: "%.1f", totalPinchDelta)) pan=\(String(format: "%.1f", panDistance)) promoted=\(canPromoteScrollToPinch)")
+            }
+
+            if gestureState == .pinching {
+                emitDebouncedPinchZoom(frameDelta: framePinchDelta, now: now)
+                lastPinchDistance = distance
+            } else {
+                logTwoFingerDebug(distance: distance, totalDelta: totalPinchDelta, rawDX: rawDX, rawDY: rawDY)
             }
 
             touchLastPosition = midpoint
 
         case 2: // Up
-            if gestureState == .twoFingerScroll || gestureState == .pinching {
+            if gestureState == .twoFingerScroll {
                 injectScrollEvent(deltaX: 0, deltaY: 0, at: midpoint, phase: .ended)
             }
+            debugLog("Two-finger ended: state=\(gestureState)")
             gestureState = .idle
             touchStartPosition = .zero
             touchLastPosition = .zero
             initialPinchDistance = 0
             lastPinchDistance = 0
+            pinchShortcutRemainder = 0
+            lastPinchShortcutTime = 0
+            lastPinchDirection = 0
 
         default:
             break
@@ -986,6 +1027,44 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if let event = CGEvent(mouseEventSource: eventSource, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left) {
             event.post(tap: .cghidEventTap)
         }
+    }
+
+    private func logTwoFingerDebug(distance: CGFloat, totalDelta: CGFloat, rawDX: CGFloat, rawDY: CGFloat) {
+        let now = DispatchTime.now().uptimeNanoseconds
+        guard now - lastTwoFingerDebugTime > 250_000_000 else { return }
+        lastTwoFingerDebugTime = now
+        debugLog(
+            "Two-finger move: state=\(gestureState) distance=\(String(format: "%.1f", distance)) " +
+            "totalDelta=\(String(format: "%.1f", totalDelta)) dx=\(String(format: "%.1f", rawDX)) dy=\(String(format: "%.1f", rawDY))"
+        )
+    }
+
+    private func emitDebouncedPinchZoom(frameDelta: CGFloat, now: UInt64) {
+        guard frameDelta != 0 else { return }
+
+        let direction = frameDelta > 0 ? 1 : -1
+        if lastPinchDirection != 0 && direction != lastPinchDirection {
+            pinchShortcutRemainder += frameDelta
+            if abs(pinchShortcutRemainder) < GestureThresholds.pinchDirectionResetDistance {
+                return
+            }
+            pinchShortcutRemainder = frameDelta
+        } else {
+            pinchShortcutRemainder += frameDelta
+        }
+
+        guard abs(pinchShortcutRemainder) >= GestureThresholds.pinchShortcutStepDistance else { return }
+        guard lastPinchShortcutTime == 0 || now - lastPinchShortcutTime >= GestureThresholds.pinchShortcutInterval else { return }
+
+        let zoomIn = pinchShortcutRemainder > 0
+        injectZoomShortcut(zoomIn: zoomIn)
+        lastPinchShortcutTime = now
+        lastPinchDirection = zoomIn ? 1 : -1
+        pinchShortcutRemainder += zoomIn ? -GestureThresholds.pinchShortcutStepDistance : GestureThresholds.pinchShortcutStepDistance
+        if abs(pinchShortcutRemainder) > GestureThresholds.pinchShortcutStepDistance {
+            pinchShortcutRemainder = 0
+        }
+        debugLog("Two-finger pinch zoom: shortcut=\(zoomIn ? "in" : "out") frame=\(String(format: "%.2f", frameDelta)) remainder=\(String(format: "%.2f", pinchShortcutRemainder))")
     }
 
     private func injectTabletEvent(at point: CGPoint, action: Int, pressure: Float, tilt: Float) {
@@ -1025,6 +1104,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         down.flags = .maskControl
         up.flags = .maskControl
+        down.post(tap: .cghidEventTap)
+        up.post(tap: .cghidEventTap)
+    }
+
+    private func injectZoomShortcut(zoomIn: Bool) {
+        let keyCode: CGKeyCode = zoomIn ? 24 : 27 // ANSI "=" and "-"
+        guard
+            let down = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCode, keyDown: true),
+            let up = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCode, keyDown: false)
+        else { return }
+
+        down.flags = .maskCommand
+        up.flags = .maskCommand
         down.post(tap: .cghidEventTap)
         up.post(tap: .cghidEventTap)
     }
@@ -1091,22 +1183,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         scrollEvent.location = position
         scrollEvent.setIntegerValueField(.scrollWheelEventIsContinuous, value: 1)
         scrollEvent.setIntegerValueField(.scrollWheelEventScrollPhase, value: Int64(phase.rawValue))
-        scrollEvent.post(tap: .cghidEventTap)
-    }
-
-    private func injectZoomEvent(delta: Int32, at position: CGPoint) {
-        guard let scrollEvent = CGEvent(
-            scrollWheelEvent2Source: eventSource,
-            units: .pixel,
-            wheelCount: 1,
-            wheel1: delta,
-            wheel2: 0,
-            wheel3: 0
-        ) else { return }
-        scrollEvent.location = position
-        scrollEvent.flags = .maskCommand
-        scrollEvent.setIntegerValueField(.scrollWheelEventIsContinuous, value: 1)
-        scrollEvent.setIntegerValueField(.scrollWheelEventScrollPhase, value: Int64(CGScrollPhase.changed.rawValue))
         scrollEvent.post(tap: .cghidEventTap)
     }
 

--- a/MacHost/Sources/AppDelegate.swift
+++ b/MacHost/Sources/AppDelegate.swift
@@ -32,6 +32,7 @@ enum GestureState {
     case dragging         // Long press + drag (left mouse drag)
     case twoFingerScroll  // 2-finger scroll
     case pinching         // Pinch zoom
+    case multiFingerSwipe // 3/4-finger system gestures
 }
 
 private enum TouchAction {
@@ -55,6 +56,11 @@ struct GestureThresholds {
     static let longPressTime: UInt64 = 500_000_000     // 500ms
     static let scrollSensitivity: CGFloat = 1.2
     static let pinchMinDistance: CGFloat = 20
+    static let pinchSensitivity: CGFloat = 1.2
+    static let minScrollDelta: CGFloat = 0.5
+    static let minPinchDelta: CGFloat = 1.0
+    static let multiFingerSwipeMinDistance: CGFloat = 70
+    static let multiFingerDirectionRatio: CGFloat = 1.25
     static let minTouchInterval: UInt64 = 8_000_000    // ~120Hz
 }
 
@@ -568,8 +574,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
 
-            streamingServer?.onTouchEvent = { [weak self] x, y, action, pointerCount, x2, y2, pressure, tilt, flags in
-                self?.handleTouch(x: x, y: y, action: action, pointerCount: pointerCount, x2: x2, y2: y2, pressure: pressure, tilt: tilt, flags: flags)
+            streamingServer?.onTouchEvent = { [weak self] x, y, action, pointerCount, x2, y2, x3, y3, x4, y4, pressure, tilt, flags in
+                self?.handleTouch(x: x, y: y, action: action, pointerCount: pointerCount, x2: x2, y2: y2, x3: x3, y3: y3, x4: x4, y4: y4, pressure: pressure, tilt: tilt, flags: flags)
             }
 
             streamingServer?.onStats = { [weak self] fps, mbps in
@@ -651,6 +657,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // 2-finger tracking
     private var initialPinchDistance: CGFloat = 0
     private var lastPinchDistance: CGFloat = 0
+    private var multiFingerStartPosition: CGPoint = .zero
+    private var multiFingerLastPosition: CGPoint = .zero
+    private var multiFingerCount = 0
+    private var multiFingerGestureTriggered = false
 
     // Momentum scrolling
     private var momentumTimer: Timer?
@@ -660,7 +670,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Touch Entry Point
 
-    func handleTouch(x: Float, y: Float, action: Int, pointerCount: Int = 1, x2: Float = 0, y2: Float = 0, pressure: Float = 0, tilt: Float = 0, flags: Int = 0) {
+    func handleTouch(x: Float, y: Float, action: Int, pointerCount: Int = 1, x2: Float = 0, y2: Float = 0, x3: Float = 0, y3: Float = 0, x4: Float = 0, y4: Float = 0, pressure: Float = 0, tilt: Float = 0, flags: Int = 0) {
         guard settings.touchEnabled else { return }
 
         if !AXIsProcessTrusted() {
@@ -685,15 +695,87 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             x: bounds.origin.x + CGFloat(x2) * bounds.width,
             y: bounds.origin.y + CGFloat(y2) * bounds.height
         )
+        let p3 = CGPoint(
+            x: bounds.origin.x + CGFloat(x3) * bounds.width,
+            y: bounds.origin.y + CGFloat(y3) * bounds.height
+        )
+        let p4 = CGPoint(
+            x: bounds.origin.x + CGFloat(x4) * bounds.width,
+            y: bounds.origin.y + CGFloat(y4) * bounds.height
+        )
 
         let isStylus = (flags & TouchFlags.stylus) != 0
         if isStylus {
             injectTabletEvent(at: p1, action: action, pressure: pressure, tilt: tilt)
+        } else if pointerCount >= 3 {
+            let points = pointerCount >= 4 ? [p1, p2, p3, p4] : [p1, p2, p3]
+            handleMultiFingerTouch(points: points, action: action)
         } else if pointerCount >= 2 {
             handleTwoFingerTouch(p1: p1, p2: p2, action: action)
         } else {
             handleOneFingerTouch(at: p1, action: action)
         }
+    }
+
+    private func handleMultiFingerTouch(points: [CGPoint], action: Int) {
+        guard let centroid = centroid(of: points) else { return }
+
+        switch action {
+        case TouchAction.down:
+            cancelLongPressTimer()
+            stopMomentumScroll()
+            gestureState = .multiFingerSwipe
+            multiFingerStartPosition = centroid
+            multiFingerLastPosition = centroid
+            multiFingerCount = points.count
+            multiFingerGestureTriggered = false
+
+        case TouchAction.move:
+            if gestureState != .multiFingerSwipe || multiFingerCount != points.count {
+                gestureState = .multiFingerSwipe
+                multiFingerStartPosition = centroid
+                multiFingerCount = points.count
+                multiFingerGestureTriggered = false
+            }
+
+            guard !multiFingerGestureTriggered else {
+                multiFingerLastPosition = centroid
+                return
+            }
+
+            let dx = centroid.x - multiFingerStartPosition.x
+            let dy = centroid.y - multiFingerStartPosition.y
+            let distance = hypot(dx, dy)
+            guard distance >= GestureThresholds.multiFingerSwipeMinDistance else {
+                multiFingerLastPosition = centroid
+                return
+            }
+
+            if abs(dx) > abs(dy) * GestureThresholds.multiFingerDirectionRatio {
+                injectSystemGestureShortcut(keyCode: dx > 0 ? 124 : 123)
+                multiFingerGestureTriggered = true
+            } else if abs(dy) > abs(dx) * GestureThresholds.multiFingerDirectionRatio {
+                injectSystemGestureShortcut(keyCode: dy > 0 ? 125 : 126)
+                multiFingerGestureTriggered = true
+            }
+            multiFingerLastPosition = centroid
+
+        case TouchAction.up:
+            gestureState = .idle
+            multiFingerGestureTriggered = false
+            multiFingerCount = 0
+
+        default:
+            break
+        }
+    }
+
+    private func centroid(of points: [CGPoint]) -> CGPoint? {
+        guard !points.isEmpty else { return nil }
+        let sum = points.reduce(CGPoint.zero) { partial, point in
+            CGPoint(x: partial.x + point.x, y: partial.y + point.y)
+        }
+        return CGPoint(x: sum.x / CGFloat(points.count), y: sum.y / CGFloat(points.count))
     }
 
     // MARK: - 1-Finger Gesture State Machine
@@ -845,50 +927,53 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         case 0: // Down
             cancelLongPressTimer()
             stopMomentumScroll()
-            gestureState = .idle  // Reset so 2-finger detection starts fresh
+            gestureState = .idle
             initialPinchDistance = distance
             lastPinchDistance = distance
             touchLastPosition = midpoint
 
         case 1: // Move
-            let distanceChange = abs(distance - initialPinchDistance)
-            let midDelta = hypot(midpoint.x - touchLastPosition.x, midpoint.y - touchLastPosition.y)
+            let rawDX = midpoint.x - touchLastPosition.x
+            let rawDY = midpoint.y - touchLastPosition.y
+            let didScroll = abs(rawDX) >= GestureThresholds.minScrollDelta || abs(rawDY) >= GestureThresholds.minScrollDelta
+            let totalPinchDelta = distance - initialPinchDistance
+            let pendingPinchDelta = distance - lastPinchDistance
+            let didPinch =
+                abs(totalPinchDelta) >= GestureThresholds.pinchMinDistance &&
+                abs(pendingPinchDelta) >= GestureThresholds.minPinchDelta
 
-            // Determine mode if not yet decided
-            if gestureState != .twoFingerScroll && gestureState != .pinching {
-                if distanceChange > GestureThresholds.pinchMinDistance {
-                    gestureState = .pinching
-                } else if midDelta > GestureThresholds.tapMaxDistance {
+            if didScroll {
+                let phase: CGScrollPhase = gestureState == .idle ? .began : .changed
+                let dx = rawDX * GestureThresholds.scrollSensitivity
+                let dy = rawDY * GestureThresholds.scrollSensitivity
+                injectScrollEvent(deltaX: dx, deltaY: dy, at: midpoint, phase: phase)
+                lastScrollDeltaX = dx
+                lastScrollDeltaY = dy
+                if gestureState == .idle {
                     gestureState = .twoFingerScroll
                 }
             }
 
-            switch gestureState {
-            case .twoFingerScroll:
-                let dx = (midpoint.x - touchLastPosition.x) * GestureThresholds.scrollSensitivity
-                let dy = (midpoint.y - touchLastPosition.y) * GestureThresholds.scrollSensitivity
-                injectScrollEvent(deltaX: dx, deltaY: dy, at: midpoint)
-
-            case .pinching:
-                let scaleDelta = distance - lastPinchDistance
-                // Cmd + scroll = zoom in most Mac apps
-                let zoomAmount = Int32(scaleDelta * 0.5)
+            if didPinch {
+                let zoomAmount = Int32((pendingPinchDelta * GestureThresholds.pinchSensitivity).rounded())
                 if zoomAmount != 0 {
                     injectZoomEvent(delta: zoomAmount, at: midpoint)
+                    gestureState = .pinching
+                    lastPinchDistance = distance
                 }
-                lastPinchDistance = distance
-
-            default:
-                break
             }
 
             touchLastPosition = midpoint
 
         case 2: // Up
+            if gestureState == .twoFingerScroll || gestureState == .pinching {
+                injectScrollEvent(deltaX: 0, deltaY: 0, at: midpoint, phase: .ended)
+            }
             gestureState = .idle
-            // Reset 1-finger tracking so leftover moves don't trigger scroll
             touchStartPosition = .zero
             touchLastPosition = .zero
+            initialPinchDistance = 0
+            lastPinchDistance = 0
 
         default:
             break
@@ -930,6 +1015,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         event.setDoubleValueField(.tabletEventTiltX, value: Double(tilt))
         event.setDoubleValueField(.tabletEventTiltY, value: 0)
         event.post(tap: .cghidEventTap)
+    }
+
+    private func injectSystemGestureShortcut(keyCode: CGKeyCode) {
+        guard
+            let down = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCode, keyDown: true),
+            let up = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCode, keyDown: false)
+        else { return }
+
+        down.flags = .maskControl
+        up.flags = .maskControl
+        down.post(tap: .cghidEventTap)
+        up.post(tap: .cghidEventTap)
     }
 
     private func performClick(at point: CGPoint) {
@@ -982,7 +1079,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func injectScrollEvent(deltaX: CGFloat, deltaY: CGFloat, at position: CGPoint) {
+    private func injectScrollEvent(deltaX: CGFloat, deltaY: CGFloat, at position: CGPoint, phase: CGScrollPhase = .changed) {
         guard let scrollEvent = CGEvent(
             scrollWheelEvent2Source: eventSource,
             units: .pixel,
@@ -992,6 +1089,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             wheel3: 0
         ) else { return }
         scrollEvent.location = position
+        scrollEvent.setIntegerValueField(.scrollWheelEventIsContinuous, value: 1)
+        scrollEvent.setIntegerValueField(.scrollWheelEventScrollPhase, value: Int64(phase.rawValue))
         scrollEvent.post(tap: .cghidEventTap)
     }
 
@@ -1005,8 +1104,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             wheel3: 0
         ) else { return }
         scrollEvent.location = position
-        // Set Cmd flag for zoom
         scrollEvent.flags = .maskCommand
+        scrollEvent.setIntegerValueField(.scrollWheelEventIsContinuous, value: 1)
+        scrollEvent.setIntegerValueField(.scrollWheelEventScrollPhase, value: Int64(CGScrollPhase.changed.rawValue))
         scrollEvent.post(tap: .cghidEventTap)
     }
 

--- a/MacHost/Sources/SettingsWindow.swift
+++ b/MacHost/Sources/SettingsWindow.swift
@@ -621,9 +621,9 @@ struct SettingsView: View {
                                     hint: "macOS privacy permission required to capture the virtual display. Grant in System Settings → Privacy & Security → Screen Recording."
                                 )
                                 StatusRow(title: "Accessibility",
-                                          status: settings.hasAccessibilityPermission ? "Granted" : "Optional",
-                                          color: settings.hasAccessibilityPermission ? .green : .orange,
-                                          hint: "Optional permission. Required only if you want touch/tap input from the tablet to control the Mac. Streaming works without it.")
+                                          status: settings.hasAccessibilityPermission ? "Granted" : (settings.touchEnabled ? "Required for Touch" : "Optional"),
+                                          color: settings.hasAccessibilityPermission ? .green : (settings.touchEnabled ? .red : .orange),
+                                          hint: "Required for touch, stylus, and mouse-event injection from the tablet. Streaming works without it.")
                                 if settings.isRunning {
                                     StatusRow(title: "Capture Method",
                                               status: settings.captureMethod,
@@ -703,7 +703,7 @@ struct SettingsView: View {
                                             Text("Enable Touch Control")
                                                 .font(.system(size: 12, weight: .medium))
                                         }
-                                        Text("Control your Mac from your tablet.")
+                                        Text("Required for touch and stylus control.")
                                             .font(.system(size: 11))
                                             .foregroundColor(.secondary)
                                         Button(action: {

--- a/MacHost/Sources/StreamingServer.swift
+++ b/MacHost/Sources/StreamingServer.swift
@@ -45,8 +45,8 @@ class StreamingServer {
     /// config is sent, for every outcome (.hevc or .h264) — so the capture
     /// pipeline can also revert to HEVC after an AVC-only client goes away.
     var onCodecNegotiated: ((StreamCodec) -> Void)?
-    // Touch callback: (x1, y1, action, pointerCount, x2, y2)
-    var onTouchEvent: ((Float, Float, Int, Int, Float, Float) -> Void)?
+    // Touch callback: (x1, y1, action, pointerCount, x2, y2, pressure, tilt, flags)
+    var onTouchEvent: ((Float, Float, Int, Int, Float, Float, Float, Float, Int) -> Void)?
     var onStats: ((Double, Double) -> Void)?
     var onKeyframeRequested: ((Bool) -> Void)?
     // Whether host wants to receive touch events from client. Ping/pong is
@@ -340,8 +340,8 @@ class StreamingServer {
         while let msgType = inputBuffer.first {
             switch msgType {
             case WireMessage.touchEvent:
-                // Touch event: 1 type + 1 pointerCount + N*(4x+4y) + 4 action.
-                // 1 finger: 14 bytes, 2 fingers: 22 bytes.
+                // Touch event: 1 type + 1 pointerCount + N*(4x+4y) + 4 action + 4 pressure + 4 tilt + 4 flags.
+                // 1 finger: 26 bytes, 2 fingers: 34 bytes.
                 guard inputBuffer.count >= 2 else { return }
 
                 let pointerCount = Int(inputByte(at: 1))
@@ -351,7 +351,7 @@ class StreamingServer {
                     continue
                 }
 
-                let expectedSize = 2 + pointerCount * 8 + 4
+                let expectedSize = 2 + pointerCount * 8 + 16
                 guard inputBuffer.count >= expectedSize else { return }
 
                 let message = Data(inputBuffer.prefix(expectedSize))
@@ -424,9 +424,12 @@ class StreamingServer {
 
         let actionOffset = 2 + pointerCount * 8
         let action = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: actionOffset, as: Int32.self) }
+        let pressure = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: actionOffset + 4, as: Float.self) }
+        let tilt = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: actionOffset + 8, as: Float.self) }
+        let flags = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: actionOffset + 12, as: Int32.self) }
 
         DispatchQueue.main.async {
-            self.onTouchEvent?(x1, y1, Int(action), pointerCount, x2, y2)
+            self.onTouchEvent?(x1, y1, Int(action), pointerCount, x2, y2, pressure, tilt, Int(flags))
         }
     }
 

--- a/MacHost/Sources/StreamingServer.swift
+++ b/MacHost/Sources/StreamingServer.swift
@@ -45,8 +45,8 @@ class StreamingServer {
     /// config is sent, for every outcome (.hevc or .h264) — so the capture
     /// pipeline can also revert to HEVC after an AVC-only client goes away.
     var onCodecNegotiated: ((StreamCodec) -> Void)?
-    // Touch callback: (x1, y1, action, pointerCount, x2, y2, pressure, tilt, flags)
-    var onTouchEvent: ((Float, Float, Int, Int, Float, Float, Float, Float, Int) -> Void)?
+    // Touch callback: (x1, y1, action, pointerCount, x2, y2, x3, y3, x4, y4, pressure, tilt, flags)
+    var onTouchEvent: ((Float, Float, Int, Int, Float, Float, Float, Float, Float, Float, Float, Float, Int) -> Void)?
     var onStats: ((Double, Double) -> Void)?
     var onKeyframeRequested: ((Bool) -> Void)?
     // Whether host wants to receive touch events from client. Ping/pong is
@@ -341,11 +341,11 @@ class StreamingServer {
             switch msgType {
             case WireMessage.touchEvent:
                 // Touch event: 1 type + 1 pointerCount + N*(4x+4y) + 4 action + 4 pressure + 4 tilt + 4 flags.
-                // 1 finger: 26 bytes, 2 fingers: 34 bytes.
+                // 1 finger: 26 bytes, 2 fingers: 34 bytes, 3 fingers: 42 bytes, 4 fingers: 50 bytes.
                 guard inputBuffer.count >= 2 else { return }
 
                 let pointerCount = Int(inputByte(at: 1))
-                guard pointerCount == 1 || pointerCount == 2 else {
+                guard (1...4).contains(pointerCount) else {
                     debugLog("Invalid touch pointer count: \(pointerCount)")
                     consumeInputBytes(1)
                     continue
@@ -417,9 +417,21 @@ class StreamingServer {
 
         var x2: Float = 0
         var y2: Float = 0
+        var x3: Float = 0
+        var y3: Float = 0
+        var x4: Float = 0
+        var y4: Float = 0
         if pointerCount >= 2 {
             x2 = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 10, as: Float.self) }
             y2 = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 14, as: Float.self) }
+        }
+        if pointerCount >= 3 {
+            x3 = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 18, as: Float.self) }
+            y3 = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 22, as: Float.self) }
+        }
+        if pointerCount >= 4 {
+            x4 = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 26, as: Float.self) }
+            y4 = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 30, as: Float.self) }
         }
 
         let actionOffset = 2 + pointerCount * 8
@@ -429,7 +441,7 @@ class StreamingServer {
         let flags = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: actionOffset + 12, as: Int32.self) }
 
         DispatchQueue.main.async {
-            self.onTouchEvent?(x1, y1, Int(action), pointerCount, x2, y2, pressure, tilt, Int(flags))
+            self.onTouchEvent?(x1, y1, Int(action), pointerCount, x2, y2, x3, y3, x4, y4, pressure, tilt, Int(flags))
         }
     }
 


### PR DESCRIPTION
## Summary
- capture Android stylus pressure, tilt, and hover events from the streamed surface
- extend the touch wire payload with stylus metadata flags
- inject stylus events on macOS as tablet-point CGEvents and clarify Accessibility permission status

## Testing
- swift build
- Android assembleDebug
- installed and manually verified local Mac/Android builds