### PR TITLE
Fix black screen on Unisoc/Spreadtrum tablets (broken HW HEVC → fall back to H.264)

### DIFF
--- a/AndroidClient/app/src/main/java/com/sidescreen/app/CodecCapabilities.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/CodecCapabilities.kt
@@ -4,16 +4,42 @@ import android.media.MediaCodecList
 import android.media.MediaFormat
 
 /**
- * One-shot decoder capability probe. AVC-only devices (e.g. Onyx Boox
- * Nova Air C, whose vendor media_codecs.xml disables HEVC) drive the
- * H.264 wire-protocol negotiation.
+ * One-shot decoder capability probe. AVC-only devices drive the H.264
+ * wire-protocol negotiation (the Mac encodes H.264 instead of HEVC).
+ *
+ * "Has HEVC" means the device has a *usable hardware* HEVC decoder — not merely
+ * any decoder that advertises the type. Two classes of device are deliberately
+ * routed to H.264 instead:
+ *
+ *  - **Software-only HEVC** (e.g. Onyx Boox Nova Air C, whose vendor
+ *    media_codecs.xml disables HW HEVC): the Google software decoder
+ *    (c2.android.hevc / OMX.google.hevc) is far too slow for real-time mirroring.
+ *
+ *  - **Broken vendor HW HEVC**: Spreadtrum/Unisoc (OMX.sprd.hevc, c2.sprd.*)
+ *    advertise a HW HEVC decoder that configures and starts successfully but
+ *    never renders decoded frames to the output Surface — the SurfaceView stays
+ *    empty and the user sees a black screen (e.g. Yuho Tab 10, SC9863A + PowerVR).
+ *
+ * Both classes have a working hardware H.264 decoder, so H.264 is the reliable
+ * path for them.
  */
 object CodecCapabilities {
+    /** Decoder-name prefixes whose HEVC implementation is unusable for surface output. */
+    private val BROKEN_HEVC_HW_PREFIXES = listOf("omx.sprd.", "c2.sprd.")
+
     val hasHevcDecoder: Boolean by lazy {
         try {
             MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.any { info ->
-                !info.isEncoder &&
+                if (info.isEncoder) return@any false
+                val handlesHevc =
                     info.supportedTypes.any { it.equals(MediaFormat.MIMETYPE_VIDEO_HEVC, ignoreCase = true) }
+                if (!handlesHevc) return@any false
+
+                val name = info.name.lowercase()
+                // Same hardware/software split VideoDecoder.findBestDecoder uses.
+                val isSoftware = name.startsWith("c2.android.") || name.startsWith("omx.google.")
+                val isBrokenHardware = BROKEN_HEVC_HW_PREFIXES.any { name.startsWith(it) }
+                !isSoftware && !isBrokenHardware
             }
         } catch (_: Exception) {
             true // fail open: assume HEVC, preserving legacy behavior


### PR DESCRIPTION
sau fix thứ nhất, vẫn còn màn đen *ngẫu nhiên* khi reconnect/quét. Tạo PR mới