### PR TITLE
fix: restore cursor and SCStream capture after display sleep/wake

### DIFF
--- a/MacHost/Sources/ScreenCapture.swift
+++ b/MacHost/Sources/ScreenCapture.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 @preconcurrency import ScreenCaptureKit
 import VideoToolbox
 import CoreMedia
@@ -49,6 +50,8 @@ class ScreenCapture {
     // Main-thread-only state
     private var frameMonitorTimer: DispatchSourceTimer?
     private var restartAttempted = false
+    private var wakeObservers: [NSObjectProtocol] = []
+    private var wakeRestartPending = false
 
     // CGDisplayStream fallback
     private var cgDisplayStream: CGDisplayStream?
@@ -158,6 +161,69 @@ class ScreenCapture {
         self.refreshRate = refreshRate
         try await setupDisplay()
         try await setupStream()
+        await MainActor.run { registerWakeObservers() }
+    }
+
+    // MARK: - Display wake handling
+
+    /// Display sleep tears down SCStream (SCStreamErrorDomain -3815, "no
+    /// displays or windows to capture"), which silently drops capture onto
+    /// the CGDisplayStream fallback for the rest of the session. Restart
+    /// the capture whenever the screens wake so it returns to SCStream.
+    private func registerWakeObservers() {
+        guard wakeObservers.isEmpty else { return }
+        let center = NSWorkspace.shared.notificationCenter
+        for name in [NSWorkspace.screensDidWakeNotification, NSWorkspace.didWakeNotification] {
+            let token = center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                self?.handleWake()
+            }
+            wakeObservers.append(token)
+        }
+        debugLog("Wake observers registered")
+    }
+
+    private func unregisterWakeObservers() {
+        let center = NSWorkspace.shared.notificationCenter
+        wakeObservers.forEach { center.removeObserver($0) }
+        wakeObservers.removeAll()
+    }
+
+    deinit {
+        // Defensive: stopStreaming() already unregisters, but make sure a
+        // dropped instance never leaves observer tokens behind.
+        unregisterWakeObservers()
+    }
+
+    private func handleWake() {
+        // Only act while a capture is actually running.
+        guard stream != nil || cgDisplayStream != nil else { return }
+        // A full system wake fires both screensDidWake and didWake —
+        // coalesce them into a single restart.
+        guard !wakeRestartPending else { return }
+        wakeRestartPending = true
+        debugLog("Screens woke — scheduling capture restart")
+        // Give WindowServer a moment to settle before touching the stream.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            guard let self else { return }
+            self.wakeRestartPending = false
+            guard self.stream != nil || self.cgDisplayStream != nil else { return }
+            // Display sleep usually kills SCStream with error -3815 ("no
+            // displays or windows to capture"), which pushes capture onto the
+            // CGDisplayStream fallback. After wake, always try to get back
+            // onto SCStream — restartStream() re-enters the fallback by
+            // itself if SCStream still cannot start.
+            let fallbackActive = self.stateLock.withLock { $0.fallbackActive }
+            if fallbackActive {
+                debugLog("Wake restart: leaving CGDisplayStream fallback, retrying SCStream")
+                self.cgDisplayStream?.stop()
+                self.cgDisplayStream = nil
+                self.stateLock.withLock { $0.fallbackActive = false }
+            }
+            self.restartStream()
+            // A wake-triggered restart must not consume the one-shot budget
+            // the frame monitor uses for stall recovery.
+            self.restartAttempted = false
+        }
     }
 
     // MARK: - SCShareableContent with timeout
@@ -496,12 +562,18 @@ class ScreenCapture {
         let pixelFormat = Int32(kCVPixelFormatType_420YpCbCr8BiPlanarFullRange)
         let queue = DispatchQueue(label: "com.sidescreen.cgdisplaystream", qos: .userInteractive)
 
+        // Without kCGDisplayStreamShowCursor the fallback stream never
+        // composites the cursor at all (the key defaults to false), so any
+        // session that degrades to CGDisplayStream loses the pointer on the
+        // tablet even when WindowServer is healthy.
+        let streamProps = [CGDisplayStream.showCursor as String: true] as CFDictionary
+
         guard let displayStream = CGDisplayStream(
             dispatchQueueDisplay: displayID,
             outputWidth: width,
             outputHeight: height,
             pixelFormat: pixelFormat,
-            properties: nil,
+            properties: streamProps,
             queue: queue,
             handler: { [weak self] _, _, frameSurface, _ in
                 guard let self = self, let surface = frameSurface else { return }
@@ -603,6 +675,7 @@ class ScreenCapture {
             state.fallbackActive = false
         }
         restartAttempted = false
+        unregisterWakeObservers()
     }
 }
 


### PR DESCRIPTION
## Problem
After the Mac's displays sleep and wake again, the mouse cursor is no longer
visible on the tablet even though the pointer has actually moved onto the
virtual display (clicks still land). The cursor stays lost for the rest of
the session.

## Root cause (two stacked issues, confirmed via /tmp/sidescreen.log)
1. When the displays go to sleep, SCStream dies with
   `SCStreamErrorDomain -3815` ("no displays or windows to capture"). The
   stream-error delegate then silently switches capture to the
   `CGDisplayStream` fallback — and the session stays on the fallback
   forever, even after wake.
2. The fallback was created with `properties: nil`, and
   `kCGDisplayStreamShowCursor` **defaults to false**, so the fallback never
   composites the cursor at all.

Net effect: any sleep/wake cycle permanently drops the session onto a
capture path that cannot show the pointer.

## Fix
- `ScreenCapture` registers `NSWorkspace.screensDidWakeNotification` /
  `didWakeNotification` observers while a capture is active (removed in
  `stopStreaming()`, with a defensive `deinit` backstop). A full system wake
  fires both notifications, so they are coalesced into a single restart.
- On wake, after a 2 s settle delay: if the fallback is active, stop it and
  retry SCStream via the existing `restartStream()` path (which re-enters
  the fallback on its own if SCStream still cannot start). The
  wake-triggered restart does not consume the frame monitor's one-shot
  stall-recovery budget.
- The `CGDisplayStream` fallback now sets `CGDisplayStream.showCursor`, so
  the pointer remains visible even while the fallback is in use.

One file changed (`MacHost/Sources/ScreenCapture.swift`), no new
dependencies, no private API.

## Testing
M1 MacBook Air, macOS 15.7.5 (24G624), Android tablet over USB, HEVC,
1280x800 HiDPI. Each scenario was verified twice (before final cleanup and
on the final patch):

1. Display sleep (no password on wake) → wake: cursor visible and persists.
2. Display sleep (password required) → unlock: cursor visible and persists.
3. Full system sleep via power button → wake: cursor visible and persists.

Log-verified sequence on every cycle:
`SCStream stopped with error … -3815` → `CGDisplayStream fallback started`
(cursor now still visible thanks to showCursor) → wake → `Wake restart:
leaving CGDisplayStream fallback, retrying SCStream` → `First frame received
from SCStream (restart)`.

Also verified: repeated sleep/wake cycles do not stack observers or
restarts, and stopping the server unregisters the observers.

## Notes — approaches tried and rejected (for reviewer context)
- **Private cursor-scale nudge** (`CGSSetCursorScale`, the programmatic
  "shake to locate"): rejected. Manual testing showed the enlarged cursor is
  visible on the tablet but the pointer disappears again the moment the
  scale returns to normal, so a transient nudge cannot fix the steady state.
  Dropping it also avoids introducing a new private API.
- **`CGDisplayHideCursor`/`CGDisplayShowCursor` toggle after wake**: was
  implemented behind a debug switch during testing and turned out to be
  unnecessary once the fallback/showCursor issue was fixed; removed from the
  final patch.
- **Restarting the capture stream alone** (without the fallback showCursor
  fix) is not sufficient — by the time the machine wakes, capture has
  already degraded to the cursor-less fallback, and a session that ever
  falls back for other reasons would still lose the pointer.
- There are reports of an OS-level cursor-compositing bug on virtual
  displays after wake (e.g. BetterDisplay discussions #999 / #2770). That
  may still exist independently on some macOS versions, but in SideScreen's
  case the dominant cause was the two issues above: on macOS 15.7.5 the
  restarted SCStream composites the cursor correctly after every wake.
