### PR TITLE
Fix màn hình đen ngẫu nhiên khi reconnect: race giữa display config và codecSelected

### DIFF
--- a/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
@@ -780,6 +780,38 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    /**
+     * Recreate the decoder when the negotiated stream codec doesn't match the
+     * decoder's mime. Display config and codecSelected can arrive in either
+     * order on reconnect; without this, a decoder created with the default
+     * HEVC mime keeps consuming the H.264 stream and never outputs a frame —
+     * a permanent black screen on AVC-only devices (e.g. Unisoc tablets).
+     */
+    private fun onStreamCodecSelected(isHevc: Boolean) {
+        val expectedMime =
+            if (isHevc) MediaFormat.MIMETYPE_VIDEO_HEVC else MediaFormat.MIMETYPE_VIDEO_AVC
+        runOnUiThread {
+            val dec = videoDecoder
+            val holder = currentSurfaceHolder
+            when {
+                dec == null -> {
+                    if (holder != null && holder.surface.isValid) {
+                        mainDiag("Codec selected ($expectedMime) — initializing deferred decoder")
+                        initializeDecoder(holder)
+                    }
+                }
+                dec.mime != expectedMime -> {
+                    mainDiag("Stream codec is $expectedMime but decoder is ${dec.mime} — recreating")
+                    dec.release()
+                    videoDecoder = null
+                    if (holder != null && holder.surface.isValid) {
+                        initializeDecoder(holder)
+                    }
+                }
+            }
+        }
+    }
+
     private fun initializeDecoder(holder: SurfaceHolder) {
         mainDiag(
             "initializeDecoder called, surface=${holder.surface}, " +
@@ -787,6 +819,13 @@ class MainActivity : AppCompatActivity() {
         )
         if (displayWidth <= 0 || displayHeight <= 0) {
             mainDiag("initializeDecoder skipped — no display config yet")
+            return
+        }
+        // AVC-only device: an HEVC decoder can never decode the H.264 stream
+        // the Mac will send — defer until codecSelected arrives, then
+        // onStreamCodecSelected initializes with the correct mime.
+        if (!CodecCapabilities.hasHevcDecoder && streamClient?.codecNegotiated != true) {
+            mainDiag("initializeDecoder deferred — AVC-only device awaiting codec negotiation")
             return
         }
         try {
@@ -904,6 +943,8 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
+
+        streamClient?.onCodecSelected = { isHevc -> onStreamCodecSelected(isHevc) }
 
         streamClient?.onDisplaySize = { width, height, rotation ->
             mainDiag("onDisplaySize: ${width}x$height @ $rotation°")
@@ -1062,6 +1103,8 @@ class MainActivity : AppCompatActivity() {
                         }
                     }
                 }
+
+                streamClient?.onCodecSelected = { isHevc -> onStreamCodecSelected(isHevc) }
 
                 streamClient?.onDisplaySize = { width, height, rotation ->
                     mainDiag("onDisplaySize: ${width}x$height @ $rotation°")

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/VideoDecoder.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/VideoDecoder.kt
@@ -18,7 +18,9 @@ class VideoDecoder(
     private val display: Display? = null,
     initialWidth: Int = 1920,
     initialHeight: Int = 1200,
-    private val mime: String = MediaFormat.MIMETYPE_VIDEO_HEVC,
+    // Exposed so MainActivity can detect a codec-negotiation/decoder mismatch
+    // and recreate the decoder (see MainActivity.onStreamCodecSelected).
+    val mime: String = MediaFormat.MIMETYPE_VIDEO_HEVC,
 ) {
     private var decoder: MediaCodec? = null
     private var decoderThread: HandlerThread? = null


### PR DESCRIPTION
Cảm ơn bạn đã merge #40! PR này là phần tiếp theo — sửa nốt lỗi **màn hình đen ngẫu nhiên khi reconnect** mà #40 chưa xử lý hết. PR này gồm 1 commit (Fix 2); Fix 1 đã được merge ở #40, nhắc lại dưới đây để làm ngữ cảnh.

## Triệu chứng
Trên **Yuho Tab 10** (Unisoc SC9863A + PowerVR, Android 11): Lần này thì mình gặp hiện tượng khi tắt hẳn app trên android và kết nối lại thì kẹt màn hình đen.
Client kết nối bình thường, stream mạng khỏe, stats overlay hiện bitrate đầy đủ — nhưng màn hình **đen hoàn toàn**. USB và wireless đều bị như nhau. Sau fix thứ nhất (#40), vẫn còn màn đen *ngẫu nhiên* khi reconnect/quét QR lại — commit này xử lý race đó.

## Ngữ cảnh: Fix 1 — định tuyến thiết bị có HW HEVC decoder hỏng sang H.264 (`CodecCapabilities.kt`, **đã merge ở #40**)

**Nguyên nhân gốc:** thiết bị khai báo có hardware HEVC decoder (`OMX.sprd.hevc.decoder`) — `configure()` và `start()` thành công nhưng **không bao giờ render frame đã giải mã ra output Surface**:

- `dumpsys SurfaceFlinger`: layer `SurfaceView` của video có `composition type=INVALID`, `buffer=0x0` — chưa từng nhận buffer nào.
- Log `VideoDecoder`: `input=540, output=0, dropped=534, availBufs=0`, liên tục `Requesting keyframe: reason=no input buffer`.
- HW composer spam mỗi frame: `SPRDHWComposer: SprdUtil Prepare failed ret: -1`.

`CodecCapabilities.hasHevcDecoder` trả về `true` chỉ vì *tồn tại* một HEVC decoder (máy này còn có `c2.android.hevc.decoder` software, nên check kiểu "có decoder HEVC nào không" luôn pass) → thiết bị negotiate HEVC và không hiển thị được gì.

**Cách sửa:** chỉ tính là "có HEVC" khi tồn tại **hardware** HEVC decoder **dùng được** — bỏ qua software decoder (quá chậm cho mirroring realtime) và denylist các prefix vendor đã biết hỏng (`omx.sprd.`, `c2.sprd.`). Các máy này sẽ đi vào đường AVC-only negotiation có sẵn (anh đã xây cho Onyx Boox), Mac stream H.264, và HW AVC decoder (`OMX.sprd.h264.decoder`) render đúng. Không đổi protocol, không đụng phía Mac.

## Fix 2 (PR này) — dựng lại decoder khi codec negotiate khác mime của decoder (`MainActivity.kt`, `VideoDecoder.kt`)

**Nguyên nhân gốc:** khi reconnect, message *display config* (type 1) có thể đến **trước** `MESSAGE_CODEC_SELECTED` (code đang giả định thứ tự ngược lại — xem comment ở `warnIfAvcOnlyWithoutNegotiation`). Khi điều đó xảy ra, decoder được tạo với mime mặc định **HEVC**; và vì chưa có ai subscribe `StreamClient.onCodecSelected` (callback đã khai báo nhưng chưa được wire), decoder sai không bao giờ được thay. HEVC decoder "nhai" luồng H.264 thì không bao giờ ra output — `input=4080, output=0`, bắt được qua DiagLog:

```
MA: Display config arrived, initializing decoder 1280x800
VD: Selected decoder: OMX.sprd.hevc.decoder      ← mime mặc định, dính race
...
SC: Server selected codec: H.264                  ← đến sau, không ai phản ứng
VD: Decode stats: input=4080, output=0            ← đen vĩnh viễn
```

**Cách sửa (3 phần):**
- Hoãn tạo decoder trên máy AVC-only cho tới khi negotiation xong (HEVC decoder không bao giờ giải mã được luồng H.264 mà máy này sẽ nhận)
- Wire `StreamClient.onCodecSelected` ở cả hai chỗ setup callback (USB + wireless): khởi tạo decoder đang hoãn, hoặc gỡ ra dựng lại khi mime không khớp codec đã chốt — nhờ đó message đến theo thứ tự nào cũng hội tụ về đúng decoder
- Mở `VideoDecoder.mime` (trước là private constructor val) để so khớp

## Tương thích

| Nhóm thiết bị | Trước | Sau |
|---|---|---|
| HW HEVC tốt (Qualcomm/MediaTek/Exynos/Tensor) | HEVC | **Không đổi** — probe vẫn `true`; guard hoãn không kích hoạt; `onCodecSelected` bắn HEVC = trùng mime → no-op |
| Unisoc/Spreadtrum (HW HEVC hỏng) | Đen vĩnh viễn | Chạy qua H.264 |
| Máy chỉ có SW HEVC (hiếm) | Decode HEVC bằng CPU (chậm) | Decode H.264 bằng HW (mượt hơn) |

Đánh đổi duy nhất: máy chỉ-có-SW-HEVC dùng với **app Mac đời cũ** (chưa hỗ trợ negotiate H.264) sẽ hiện thông báo "update the Mac app" có sẵn thay vì video SW-HEVC chậm — cùng đánh đổi mà đường AVC-only hiện tại đã chấp nhận.

## Kiểm thử

Build và verify trên Yuho Tab 10 qua wireless:

```
SC: Advertised AVC-only (no HEVC decoder on this device)
SC: Server selected codec: H.264
MA: Codec selected (video/avc) — initializing deferred decoder
VD: Selected decoder: OMX.sprd.h264.decoder
VD: First output frame! size=2820096
VD: Decode stats: input=540, output=536, dropped=0, availBufs=8
```

Trước fix, race khi reconnect tái hiện đều đặn (đen khoảng một nửa số lần quét QR lại); sau fix, decoder hội tụ về H.264 với mọi thứ tự kết nối, tablet hiển thị desktop Mac bình thường.