### PR TITLE
fix(mac): release remote drag during touch teardown

### DIFF
--- a/MacHost/Sources/AppDelegate.swift
+++ b/MacHost/Sources/AppDelegate.swift
@@ -240,7 +240,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         settings.$touchEnabled
             .dropFirst()
             .sink { [weak self] enabled in
-                self?.streamingServer?.touchEnabled = enabled
+                guard let self else { return }
+                self.streamingServer?.touchEnabled = enabled
+                if !enabled {
+                    self.cancelActiveRemoteGesture()
+                }
             }
             .store(in: &cancellables)
 
@@ -634,6 +638,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             streamingServer?.onClientDisconnected = { [weak self] in
                 guard let self = self else { return }
                 Task { @MainActor in
+                    self.cancelActiveRemoteGesture()
                     self.settings.clientConnected = false
                     // Final lastConnected snapshot at the disconnect moment, then
                     // freeze (currentWirelessDevice = nil stops the rolling update
@@ -688,6 +693,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func stopServer() {
+        cancelActiveRemoteGesture()
+
         // Save display position before destroying
         virtualDisplayManager?.saveDisplayPosition()
 
@@ -735,6 +742,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var momentumVelocityX: CGFloat = 0
     private var momentumVelocityY: CGFloat = 0
     private var lastMomentumPosition: CGPoint = .zero
+
+    /// Balance any synthetic mouse-down before remote touch control goes away
+    /// or changes to a gesture that no longer owns the mouse button.
+    private func cancelActiveRemoteGesture() {
+        cancelLongPressTimer()
+        stopMomentumScroll()
+        if gestureState == .dragging {
+            injectMouseUp(at: touchLastPosition)
+        }
+        gestureState = .idle
+    }
 
     // MARK: - Touch Entry Point
 
@@ -918,9 +936,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         switch action {
         case 0: // Down
-            cancelLongPressTimer()
-            stopMomentumScroll()
-            gestureState = .idle  // Reset so 2-finger detection starts fresh
+            // A second finger can arrive while a long-press drag owns the
+            // synthetic left button. Release it before replacing that state.
+            cancelActiveRemoteGesture()
             initialPinchDistance = distance
             lastPinchDistance = distance
             touchLastPosition = midpoint


### PR DESCRIPTION
## What changed

Centralize remote gesture cleanup and run it when:

- touch input is disabled
- the Android client disconnects
- the Mac server stops
- a one-finger gesture transitions to two fingers

If SideScreen previously posted a synthetic `leftMouseDown` for a long-press drag, cleanup now posts the matching `leftMouseUp`. It also cancels pending long-press and momentum-scroll work before returning the gesture state to idle.

## Why

The long-press drag path posts `leftMouseDown` when movement begins. Some interruption paths previously discarded the `.dragging` state without posting `leftMouseUp`.

One reproducible case is placing a second finger while dragging: Android sends a two-pointer down event, and the Mac host immediately replaced `.dragging` with the two-finger state. The active application could then continue behaving as though the left mouse button was held.

The same imbalance was possible if touch was disabled, the client disconnected, or the server stopped during a drag.

## Validation

- `swift test` — 35 tests passed
- Clean ARM64 release build
- No Android or wire-protocol changes
