### PR TITLE
feat(mac): Pen / Draw Mode — single pointer draws instead of scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Pen / Draw Mode.** New toggle under Touch Control on the Mac. With it on, a single pointer presses the left button the moment it touches down instead of waiting out the long-press threshold, so a stylus draws a continuous stroke in drawing apps rather than scrolling the canvas. Two-finger scroll and pinch are unchanged, so panning and zooming still work. Off by default — every existing gesture behaves exactly as before unless it is enabled. This is direct-pointer input only: the touch protocol carries no pressure or tilt, so it does not close out the planned full stylus support.
+
+### Fixed
+- **Left mouse button could stay stuck down.** A drag that never received its touch-up — client disconnected, server stopped, touch input switched off, or the app quit mid-drag — left the left button physically pressed, so every later cursor movement dragged across the Mac until a real mouse was clicked. All of those paths now release the button. Rare with long-press dragging, but constant once Pen / Draw Mode makes a held button the normal state of every stroke.
+
 ### Planned
 - mDNS auto-discovery for wireless mode
 - Audio streaming

--- a/MacHost/Sources/AppDelegate.swift
+++ b/MacHost/Sources/AppDelegate.swift
@@ -733,6 +733,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // Double tap tracking
     private var lastTapTime: UInt64 = 0
     private var lastTapPosition: CGPoint = .zero
+    /// Click count of the pen press currently held down, so its release can match it.
+    private var penClickState: Int64 = 1
 
     // Long press timer
     private var longPressTimer: DispatchWorkItem?
@@ -820,12 +822,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         touchStartPosition = point
         touchLastPosition = point
+        touchStartTime = DispatchTime.now().uptimeNanoseconds
         gestureState = .penDrawing
+
+        // A press has to declare its click count up front: a second tap that lands close
+        // enough to the first, soon enough after it, is click 2 of a double click. The
+        // trackpad path decides this on mouse-up because it buffers the whole tap; pen
+        // mode presses on contact, so the decision moves here.
+        let doubleTapWindow = touchStartTime - lastTapTime < GestureThresholds.doubleTapMaxTime
+        let doubleTapReach = hypot(point.x - lastTapPosition.x, point.y - lastTapPosition.y)
+            < GestureThresholds.doubleTapMaxDistance
+        penClickState = (lastTapTime != 0 && doubleTapWindow && doubleTapReach) ? 2 : 1
 
         // Park the cursor on the contact point first so the app sees the press where
         // the pen actually is, then press immediately (no long-press threshold).
         moveCursor(to: point)
-        injectMouseDown(at: point)
+        injectMouseDown(at: point, clickState: penClickState)
     }
 
     private func penMove(to point: CGPoint) {
@@ -846,11 +858,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // .dragging is possible if the mode was switched on mid-stroke — release either way,
         // a stuck left button would be worse than a lost stroke.
         guard gestureState == .penDrawing || gestureState == .dragging else { return }
-        // clickState marks this as the release of a complete click, matching the down
-        // event; without it a tap is a half-formed click and controls that act on
-        // mouseUp ignore it.
-        injectMouseUp(at: point, clickState: 1)
+        // Match the click count of the press. Without it the release reads as a
+        // half-formed click and controls that act on mouse-up ignore it.
+        injectMouseUp(at: point, clickState: penClickState)
         gestureState = .idle
+
+        // Only a short, stationary contact can start or continue a double tap; a drawn
+        // stroke that happens to end near an earlier tap must not chain into one.
+        let now = DispatchTime.now().uptimeNanoseconds
+        let travelled = hypot(point.x - touchStartPosition.x, point.y - touchStartPosition.y)
+        let wasTap = travelled < GestureThresholds.tapMaxDistance
+            && now - touchStartTime < GestureThresholds.tapMaxTime
+
+        if wasTap && penClickState == 1 {
+            lastTapTime = now
+            lastTapPosition = point
+        } else {
+            // Reset after click 2 as well, so a third tap doesn't ride the same window.
+            lastTapTime = 0
+        }
+        penClickState = 1
     }
 
     /// Releases the left button if a state that holds it down is still active, then resets
@@ -862,6 +889,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard gestureState == .penDrawing || gestureState == .dragging else { return }
         injectMouseUp(at: touchLastPosition)
         gestureState = .idle
+        penClickState = 1
+        lastTapTime = 0
     }
 
     private func oneFingerDown(at point: CGPoint) {
@@ -1095,9 +1124,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func injectMouseDown(at point: CGPoint) {
+    private func injectMouseDown(at point: CGPoint, clickState: Int64 = 1) {
         if let event = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left) {
-            event.setIntegerValueField(.mouseEventClickState, value: 1)
+            event.setIntegerValueField(.mouseEventClickState, value: clickState)
             event.post(tap: .cghidEventTap)
         }
     }

--- a/MacHost/Sources/AppDelegate.swift
+++ b/MacHost/Sources/AppDelegate.swift
@@ -30,6 +30,7 @@ enum GestureState {
     case scrolling        // 1-finger scroll
     case longPressReady   // Long press detected, waiting for drag or release
     case dragging         // Long press + drag (left mouse drag)
+    case penDrawing       // Pen mode: 1-pointer stroke (mouse down on touch, no long press)
     case twoFingerScroll  // 2-finger scroll
     case pinching         // Pinch zoom
 }
@@ -240,6 +241,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         settings.$touchEnabled
             .dropFirst()
             .sink { [weak self] enabled in
+                // Turning touch off mid-stroke drops every later event, up included, so
+                // close the stroke before the events stop flowing.
+                if !enabled { self?.releaseHeldMouseButtonIfNeeded() }
                 self?.streamingServer?.touchEnabled = enabled
             }
             .store(in: &cancellables)
@@ -634,6 +638,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             streamingServer?.onClientDisconnected = { [weak self] in
                 guard let self = self else { return }
                 Task { @MainActor in
+                    // The tablet can vanish mid-stroke (cable pulled, app killed); its
+                    // touch-up will never arrive, so end any open stroke here.
+                    self.releaseHeldMouseButtonIfNeeded()
                     self.settings.clientConnected = false
                     // Final lastConnected snapshot at the disconnect moment, then
                     // freeze (currentWirelessDevice = nil stops the rolling update
@@ -688,6 +695,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func stopServer() {
+        // A stroke can be in flight when the user hits Stop; release before the input
+        // path goes away, or the left button stays down with nothing left to lift it.
+        releaseHeldMouseButtonIfNeeded()
+
         // Save display position before destroying
         virtualDisplayManager?.saveDisplayPosition()
 
@@ -766,6 +777,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         if pointerCount >= 2 {
             handleTwoFingerTouch(p1: p1, p2: p2, action: action)
+        } else if settings.penModeEnabled {
+            // Pen mode: single pointer draws directly. 2-finger gestures above are
+            // untouched, so scroll/pinch still work for panning and zooming a canvas.
+            handlePenTouch(at: p1, action: action)
         } else {
             handleOneFingerTouch(at: p1, action: action)
         }
@@ -780,6 +795,73 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         case 2: oneFingerUp(at: point)
         default: break
         }
+    }
+
+    // MARK: - Pen / Draw Mode (1 pointer, direct pointer semantics)
+
+    /// Pen mode maps one pointer straight onto the left mouse button: down → drag → up,
+    /// with no long-press wait and no scroll interpretation, so a stroke produces a
+    /// continuous line in drawing apps. A tap is still a plain click (down + up).
+    private func handlePenTouch(at point: CGPoint, action: Int) {
+        switch action {
+        case 0: penDown(at: point)
+        case 1: penMove(to: point)
+        case 2: penUp(at: point)
+        default: break
+        }
+    }
+
+    private func penDown(at point: CGPoint) {
+        stopMomentumScroll()
+        cancelLongPressTimer()
+        // A previous stroke can still be open if its up event never arrived (client
+        // dropped mid-stroke); never stack two downs without an up in between.
+        releaseHeldMouseButtonIfNeeded()
+
+        touchStartPosition = point
+        touchLastPosition = point
+        gestureState = .penDrawing
+
+        // Park the cursor on the contact point first so the app sees the press where
+        // the pen actually is, then press immediately (no long-press threshold).
+        moveCursor(to: point)
+        injectMouseDown(at: point)
+    }
+
+    private func penMove(to point: CGPoint) {
+        guard gestureState == .penDrawing else { return }
+
+        // Same input-rate cap as the trackpad path (~120Hz); above that the extra
+        // samples only cost CGEvent posts.
+        let now = DispatchTime.now().uptimeNanoseconds
+        if now - lastTouchTime < GestureThresholds.minTouchInterval { return }
+        lastTouchTime = now
+
+        injectMouseDragged(to: point)
+
+        touchLastPosition = point
+    }
+
+    private func penUp(at point: CGPoint) {
+        // .dragging is possible if the mode was switched on mid-stroke — release either way,
+        // a stuck left button would be worse than a lost stroke.
+        guard gestureState == .penDrawing || gestureState == .dragging else { return }
+        // clickState marks this as the release of a complete click, matching the down
+        // event; without it a tap is a half-formed click and controls that act on
+        // mouseUp ignore it.
+        injectMouseUp(at: point, clickState: 1)
+        gestureState = .idle
+    }
+
+    /// Releases the left button if a state that holds it down is still active, then resets
+    /// the gesture. Called whenever a stroke can no longer be finished normally — a second
+    /// finger landing mid-stroke, the client disconnecting, the server stopping, touch input
+    /// being turned off, or the app quitting. Without this the button stays physically down
+    /// and every later cursor move drags across the Mac until the user clicks a real mouse.
+    private func releaseHeldMouseButtonIfNeeded() {
+        guard gestureState == .penDrawing || gestureState == .dragging else { return }
+        injectMouseUp(at: touchLastPosition)
+        gestureState = .idle
     }
 
     private func oneFingerDown(at point: CGPoint) {
@@ -846,7 +928,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 lastScrollDeltaY = sy
             }
 
-        case .dragging:
+        case .dragging, .penDrawing:
+            // .penDrawing only lands here if pen mode was switched off mid-stroke; keep
+            // feeding drags so the button that is still down doesn't sit in one spot.
             injectMouseDragged(to: point)
 
         default:
@@ -900,7 +984,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
 
-        case .dragging:
+        case .dragging, .penDrawing:
+            // .penDrawing only lands here if the mode was switched off mid-stroke.
             injectMouseUp(at: point)
 
         default:
@@ -918,6 +1003,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         switch action {
         case 0: // Down
+            releaseHeldMouseButtonIfNeeded()
             cancelLongPressTimer()
             stopMomentumScroll()
             gestureState = .idle  // Reset so 2-finger detection starts fresh
@@ -1022,8 +1108,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func injectMouseUp(at point: CGPoint) {
+    /// `clickState` defaults to 0 so the existing drag paths post exactly the event they
+    /// always have; only taps that need to read as a complete click pass 1.
+    private func injectMouseUp(at point: CGPoint, clickState: Int64 = 0) {
         if let event = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left) {
+            if clickState > 0 {
+                event.setIntegerValueField(.mouseEventClickState, value: clickState)
+            }
             event.post(tap: .cghidEventTap)
         }
     }

--- a/MacHost/Sources/SettingsWindow.swift
+++ b/MacHost/Sources/SettingsWindow.swift
@@ -485,7 +485,7 @@ struct SettingsView: View {
                                 .disabled(!settings.touchEnabled)
 
                                 if settings.penModeEnabled && settings.touchEnabled {
-                                    Text("Drawing mode is on — 1-finger scroll, momentum, double tap and tap-and-hold right click are off. Two fingers still scroll and pinch.")
+                                    Text("Drawing mode is on — 1-finger scroll, momentum and tap-and-hold right click are off. Tap, double tap, two-finger scroll and pinch still work.")
                                         .font(.system(size: 10))
                                         .foregroundColor(.orange)
                                 }

--- a/MacHost/Sources/SettingsWindow.swift
+++ b/MacHost/Sources/SettingsWindow.swift
@@ -467,6 +467,28 @@ struct SettingsView: View {
                                         .font(.system(size: 10))
                                         .foregroundColor(.orange)
                                 }
+
+                                Divider()
+
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text("Pen / Draw Mode")
+                                            .font(.system(size: 12, weight: .medium))
+                                        Text("Draw with a stylus instead of scrolling")
+                                            .font(.system(size: 10))
+                                            .foregroundColor(.secondary)
+                                    }
+                                    Spacer()
+                                    Toggle("", isOn: $settings.penModeEnabled)
+                                        .labelsHidden()
+                                }
+                                .disabled(!settings.touchEnabled)
+
+                                if settings.penModeEnabled && settings.touchEnabled {
+                                    Text("Drawing mode is on — 1-finger scroll, momentum, double tap and tap-and-hold right click are off. Two fingers still scroll and pinch.")
+                                        .font(.system(size: 10))
+                                        .foregroundColor(.orange)
+                                }
                             }
                         }
 
@@ -1184,6 +1206,9 @@ class DisplaySettings: ObservableObject {
     @Published var touchEnabled: Bool {
         didSet { save("touchEnabled", touchEnabled) }
     }
+    @Published var penModeEnabled: Bool {
+        didSet { save("penModeEnabled", penModeEnabled) }
+    }
     @Published var connectionMode: ConnectionMode {
         didSet { save("connectionMode", connectionMode.rawValue) }
     }
@@ -1231,6 +1256,8 @@ class DisplaySettings: ObservableObject {
         self.customWidth = defaults.object(forKey: keyPrefix + "customWidth") as? Int ?? 1920
         self.customHeight = defaults.object(forKey: keyPrefix + "customHeight") as? Int ?? 1200
         self.touchEnabled = defaults.object(forKey: keyPrefix + "touchEnabled") as? Bool ?? true
+        // Default off: without it the touch pipeline keeps its original trackpad behaviour.
+        self.penModeEnabled = defaults.object(forKey: keyPrefix + "penModeEnabled") as? Bool ?? false
         let modeRaw = defaults.string(forKey: keyPrefix + "connectionMode") ?? ConnectionMode.usb.rawValue
         self.connectionMode = ConnectionMode(rawValue: modeRaw) ?? .usb
         self.autoStartStreamingOnLaunch = defaults.object(forKey: keyPrefix + "autoStartStreamingOnLaunch") as? Bool ?? false
@@ -1299,7 +1326,8 @@ class DisplaySettings: ObservableObject {
     func resetToDefaults() {
         let keys = ["resolution", "refreshRate", "hiDPI", "bitrate", "quality",
                     "gamingBoost", "port", "rotation", "flipHorizontal", "flipVertical", "showAllResolutions",
-                    "customWidth", "customHeight", "touchEnabled", "autoStartStreamingOnLaunch", "startupMode"]
+                    "customWidth", "customHeight", "touchEnabled", "penModeEnabled",
+                    "autoStartStreamingOnLaunch", "startupMode"]
         for key in keys {
             defaults.removeObject(forKey: keyPrefix + key)
         }
@@ -1318,6 +1346,7 @@ class DisplaySettings: ObservableObject {
         customWidth = 1920
         customHeight = 1200
         touchEnabled = true
+        penModeEnabled = false
         autoStartStreamingOnLaunch = false
         startupMode = .usb
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ First-time setup still needs a screen once to grant Screen Recording permission;
 | HiDPI (Retina) | On/Off | Off |
 | Gaming Boost | On/Off (1 Gbps, 120 Hz) | Off |
 | Touch Input | On/Off | On |
+| Pen / Draw Mode | On/Off | Off |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **Pen / Draw Mode**, a Touch Control toggle that routes a single pointer straight onto the left mouse button so a stylus draws instead of scrolling.

Closes #45.

The gesture state machine currently treats one pointer as a trackpad: a stroke that travels further than `tapMaxDistance` before `longPressTime` elapses becomes a scroll, so drawing pans the canvas. Waiting out the 500 ms long press before every stroke is the only way to get a line today, which is unusable for drawing.

With the toggle on, and for a single pointer only:

- touch down → `leftMouseDown` immediately, no long-press wait
- touch move → `leftMouseDragged`
- touch up → `leftMouseUp` (with `mouseEventClickState` set, so a tap still reads as a complete click)

Two pointers are dispatched **before** the mode is consulted, so two-finger scroll and pinch are untouched and panning/zooming a canvas still works.

**Off by default.** When the toggle is off the only changes on the existing path are one `Bool` read and two branches that are unreachable unless the mode has been enabled, so every current gesture behaves exactly as before.

This is direct-pointer input only. The touch payload carries `x, y, action, pointerCount` and no pressure or tilt, so this deliberately does **not** close out the planned full stylus support — it is the small, Mac-only half of #45 that needs no wire-protocol or Android change.

## Relationship to open PRs

- **#33 (stylus pressure/tilt/hover)** is the larger, more complete answer and changes the wire protocol and the Android client. This PR is not a competitor: if #33 lands, this toggle can be dropped or folded into it. It exists because it is 2 files, Mac-only, and gives #45 a working stroke today.
- **#46 (release remote drag during touch teardown)** overlaps this PR's teardown fix — we independently hit the same stuck-button problem and centralised the same four paths. Happy to rebase on top of #46 and drop the duplicate part if #46 goes in first; the pen path cannot ship without that fix, since it makes a held button the normal state of every stroke rather than a rare long-press case.

## Also fixed

`releaseHeldMouseButtonIfNeeded()` posts the matching `leftMouseUp` whenever a stroke can end without its touch-up: client disconnect, `stopServer()`, touch input switched off, a second finger landing mid-stroke, and a fresh pen down that finds a previous stroke still open. Without it, pulling the USB cable mid-stroke leaves the left button physically down and every later cursor move drags across the Mac until a real mouse is clicked.

It guards on `.penDrawing || .dragging`, so it also covers the pre-existing long-press drag case (same ground as #46).

## Known limitations

- No pressure or tilt (protocol carries neither) — see #33.
- While the mode is on, one-finger scroll, momentum and tap-and-hold right click are unavailable. Tap and double tap still work. The Settings panel says so in an orange note.
- Stroke smoothness is bounded by the client: `MainActivity` runs one-finger moves through `InputPredictor.predictPosition(12f)` and reads only `event.x/y` rather than `getHistorical*`, so fast strokes can overshoot slightly at sharp corners. Left alone deliberately to keep this PR Mac-only.

## Testing

Verified:
- `swift build` clean, no warnings
- `scripts/build_mac.sh` produces the universal bundle; installed and launched on macOS 26.5.2, Apple Silicon
- Toggle appears under Touch Control and persists across restarts (`defaults read com.sidescreen.app SideScreen_penModeEnabled`)
- Default-off path re-read line by line: no existing line removed or moved, all new code unreachable with the toggle off

Not yet verified, which is why this is a draft:
- Cable-pull mid-stroke actually leaving the button released

Verified on hardware (Xiaomi Pad 6, USB, macOS 26.5.2):
- Long continuous strokes draw as expected instead of scrolling
- Two-finger scroll and pinch still work with the mode on
- Double tap opens items (this needed the follow-up commit: a press declares its click count when posted, so pen mode has to decide at contact rather than on release)

Hardware here is a Xiaomi Pad 6 over USB. The reporter of #45 offered to test builds — happy to have this exercised on a Redmi Pad Pro before it is marked ready.

## UI

The toggle sits under Touch Control directly below "Enable Touch Input", disabled when touch input is off, with a note listing what the mode turns off. Screenshot to follow before this leaves draft.
