### PR TITLE
fix(mac): stop setupStream crashing when streamOutput is cleared mid-setup

### DIFF
--- a/MacHost/Sources/ScreenCapture.swift
+++ b/MacHost/Sources/ScreenCapture.swift
@@ -318,7 +318,11 @@ class ScreenCapture {
         let (width, height) = encodeSize(for: codec)
         let fps = refreshRate
 
-        streamOutput = StreamOutput()
+        // Keep a local reference. `streamOutput` is cleared by the restart, fallback
+        // and stop paths, so force-unwrapping the property further down races with
+        // any of them and crashes setup with "Unexpectedly found nil".
+        let output = StreamOutput()
+        streamOutput = output
 
         let delegate = StreamDelegate()
         delegate.onStreamError = { [weak self] _ in
@@ -345,7 +349,7 @@ class ScreenCapture {
         config.scalesToFit = false
 
         let scStream = SCStream(filter: filter, configuration: config, delegate: delegate)
-        try scStream.addStreamOutput(streamOutput!, type: .screen, sampleHandlerQueue: .global(qos: .userInteractive))
+        try scStream.addStreamOutput(output, type: .screen, sampleHandlerQueue: .global(qos: .userInteractive))
 
         stream = scStream
         debugLog("Stream configured: \(width)x\(height) @ \(fps)fps (with delegate)")


### PR DESCRIPTION
## Problem

`ScreenCapture.setupStream()` assigns `streamOutput` and then force-unwraps the property about 25 lines later to hand it to `addStreamOutput`:

```swift
streamOutput = StreamOutput()
// ... ~25 lines of filter/config setup ...
try scStream.addStreamOutput(streamOutput!, type: .screen, sampleHandlerQueue: ...)
```

The restart, fallback and stop paths all set `streamOutput = nil`. If any of them runs inside that window the unwrap traps and the app dies:

```
Swift runtime failure: Unexpectedly found nil while unwrapping an Optional value
  ScreenCapture.setupStream()
  AppDelegate.startServer()
  closure #1 in closure #1 in AppDelegate.setupSettingsWindow()
```

I hit this starting the server in wireless mode: the display came up, then the process died ~8 seconds later with the log sitting between `Capturing virtual display` and `Stream configured` — exactly the span between the assignment and the unwrap. It is a race, so it does not reproduce on every launch.

## Fix

Hold the value in a local for the duration of setup. The property is still assigned for the other call sites, and the happy path is unchanged.

```swift
let output = StreamOutput()
streamOutput = output
// ...
try scStream.addStreamOutput(output, type: .screen, sampleHandlerQueue: ...)
```

## Checks

- `swift build -c release` on this branch
- `swiftlint lint --config .swiftlint.yml --strict` — 0 violations

One file, +6/-2.