### PR TITLE
fix(mac): make server startup lifecycle reliable

### DIFF
--- a/MacHost/Sources/AppDelegate.swift
+++ b/MacHost/Sources/AppDelegate.swift
@@ -601,7 +601,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             // Setup capture
-            guard let displayID = virtualDisplayManager?.displayID else { return }
+            guard let displayID = virtualDisplayManager?.displayID else {
+                throw NSError(
+                    domain: "SideScreen.Startup",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "The virtual display was created without a display ID."]
+                )
+            }
             screenCapture = try await ScreenCapture()
             screenCapture?.onCaptureMethodChanged = { [weak self] method in
                 guard let self = self else { return }
@@ -688,9 +694,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
 
-            streamingServer?.start()
+            guard let server = streamingServer else {
+                throw NSError(
+                    domain: "SideScreen.Startup",
+                    code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: "The streaming server could not be created."]
+                )
+            }
+            try await server.start()
             screenCapture?.startStreaming(
-                to: streamingServer,
+                to: server,
                 bitrateMbps: settings.effectiveBitrate,
                 quality: settings.effectiveQuality,
                 gamingBoost: settings.gamingBoost,
@@ -705,8 +718,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } catch {
             print("❌ Failed to start: \(error)")
             await MainActor.run {
-                settings.isRunning = false
-                settings.displayCreated = false
+                self.tearDownServerResources(saveDisplayPosition: false)
 
                 let alert = NSAlert()
                 alert.messageText = "Failed to Start Server"
@@ -749,9 +761,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    func stopServer() {
-        // Save display position before destroying
-        virtualDisplayManager?.saveDisplayPosition()
+    private func tearDownServerResources(saveDisplayPosition: Bool) {
+        if saveDisplayPosition {
+            virtualDisplayManager?.saveDisplayPosition()
+        }
         settings.pairingCode = nil
         streamingServer?.expectedPairingCode = nil
 
@@ -759,11 +772,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         streamingServer?.stop()
         virtualDisplayManager?.destroyDisplay()
 
+        screenCapture = nil
+        streamingServer = nil
+        virtualDisplayManager = nil
+        currentWirelessDevice = nil
+
         settings.isRunning = false
         settings.displayCreated = false
         settings.clientConnected = false
+        settings.currentWirelessDevice = nil
         settings.currentFPS = 0
         settings.currentBitrate = 0
+    }
+
+    func stopServer() {
+        tearDownServerResources(saveDisplayPosition: true)
 
         print("⏹️ Server stopped")
     }

--- a/MacHost/Sources/StreamingServer.swift
+++ b/MacHost/Sources/StreamingServer.swift
@@ -40,6 +40,102 @@ private extension NWEndpoint {
     }
 }
 
+enum StreamingServerStartError: LocalizedError {
+    case listenerFailed(port: UInt16, underlying: Error)
+    case cancelledBeforeReady(port: UInt16)
+    case startupTimedOut(port: UInt16, lastWaitingError: Error?)
+
+    var errorDescription: String? {
+        switch self {
+        case .listenerFailed(let port, let underlying):
+            return "Could not listen on port \(port): \(underlying.localizedDescription)"
+        case .cancelledBeforeReady(let port):
+            return "Server startup on port \(port) was cancelled before the listener became ready."
+        case .startupTimedOut(let port, let lastWaitingError):
+            let detail = lastWaitingError.map { " Last listener error: \($0.localizedDescription)" } ?? ""
+            return "Timed out while waiting for the server to listen on port \(port).\(detail)"
+        }
+    }
+}
+
+/// Bridges NWListener's state callback to async startup without risking a
+/// leaked or double-resumed continuation. The listener may publish a state
+/// before `wait()` installs its continuation, so the first result is cached.
+final class ListenerStartupGate: @unchecked Sendable {
+    private enum State {
+        case pending
+        case waiting(CheckedContinuation<Void, Error>)
+        case completed(Result<Void, Error>)
+    }
+
+    private let lock = NSLock()
+    private var state: State = .pending
+    private var lastWaitingError: Error?
+
+    func wait() async throws {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let completedResult: Result<Void, Error>?
+                lock.lock()
+                switch state {
+                case .pending:
+                    state = .waiting(continuation)
+                    completedResult = nil
+                case .completed(let result):
+                    completedResult = result
+                case .waiting:
+                    // A StreamingServer has exactly one startup waiter.
+                    completedResult = .failure(
+                        NSError(
+                            domain: "StreamingServer",
+                            code: 1,
+                            userInfo: [NSLocalizedDescriptionKey: "Server startup was awaited more than once."]
+                        )
+                    )
+                }
+                lock.unlock()
+
+                if let completedResult {
+                    continuation.resume(with: completedResult)
+                }
+            }
+        } onCancel: {
+            resolve(.failure(CancellationError()))
+        }
+    }
+
+    func noteWaitingError(_ error: Error) {
+        lock.lock()
+        lastWaitingError = error
+        lock.unlock()
+    }
+
+    func resolveTimeout(port: UInt16) {
+        lock.lock()
+        let waitingError = lastWaitingError
+        lock.unlock()
+        resolve(.failure(StreamingServerStartError.startupTimedOut(port: port, lastWaitingError: waitingError)))
+    }
+
+    func resolve(_ result: Result<Void, Error>) {
+        let continuation: CheckedContinuation<Void, Error>?
+        lock.lock()
+        switch state {
+        case .pending:
+            state = .completed(result)
+            continuation = nil
+        case .waiting(let waiter):
+            state = .completed(result)
+            continuation = waiter
+        case .completed:
+            continuation = nil
+        }
+        lock.unlock()
+
+        continuation?.resume(with: result)
+    }
+}
+
 class StreamingServer {
     private let port: UInt16
     private var listener: NWListener?
@@ -128,8 +224,16 @@ class StreamingServer {
         self.port = port
     }
 
-    func start() {
+    var boundPort: UInt16? {
+        listener?.port?.rawValue
+    }
+
+    func start(startupTimeout: TimeInterval = 10) async throws {
         isStopped = false
+        let startupGate = ListenerStartupGate()
+        let startupPort = port
+
+        let newListener: NWListener
         do {
             let params = NWParameters.tcp
             params.allowLocalEndpointReuse = true
@@ -139,26 +243,69 @@ class StreamingServer {
                 tcpOptions.noDelay = true  // Disable Nagle's algorithm
             }
 
-            listener = try NWListener(using: params, on: NWEndpoint.Port(integerLiteral: port))
-
-            listener?.newConnectionHandler = { [weak self] newConnection in
-                self?.handleConnection(newConnection)
-            }
-
-            listener?.stateUpdateHandler = { state in
-                switch state {
-                case .ready:
-                    debugLog("TCP Server listening on port \(self.port)")
-                case .failed(let error):
-                    debugLog("Server failed: \(error)")
-                default:
-                    break
-                }
-            }
-
-            listener?.start(queue: networkQueue)
+            newListener = try NWListener(using: params, on: NWEndpoint.Port(integerLiteral: port))
         } catch {
             debugLog("Failed to start server: \(error)")
+            throw StreamingServerStartError.listenerFailed(port: port, underlying: error)
+        }
+
+        listener = newListener
+        newListener.newConnectionHandler = { [weak self] newConnection in
+            self?.handleConnection(newConnection)
+        }
+
+        newListener.stateUpdateHandler = { [weak self, startupGate] state in
+            guard let self else {
+                startupGate.resolve(.failure(CancellationError()))
+                return
+            }
+            switch state {
+            case .ready:
+                debugLog("TCP Server listening on port \(self.port)")
+                startupGate.resolve(.success(()))
+            case .waiting(let error):
+                debugLog("Server waiting to listen: \(error)")
+                if case .posix(.EADDRINUSE) = error {
+                    startupGate.resolve(
+                        .failure(StreamingServerStartError.listenerFailed(port: self.port, underlying: error))
+                    )
+                } else {
+                    startupGate.noteWaitingError(error)
+                }
+            case .failed(let error):
+                debugLog("Server failed: \(error)")
+                startupGate.resolve(
+                    .failure(StreamingServerStartError.listenerFailed(port: self.port, underlying: error))
+                )
+            case .cancelled:
+                startupGate.resolve(
+                    .failure(StreamingServerStartError.cancelledBeforeReady(port: self.port))
+                )
+            default:
+                break
+            }
+        }
+
+        let timeoutWorkItem = DispatchWorkItem { [startupGate] in
+            startupGate.resolveTimeout(port: startupPort)
+        }
+        networkQueue.asyncAfter(
+            deadline: .now() + max(0, startupTimeout),
+            execute: timeoutWorkItem
+        )
+        newListener.start(queue: networkQueue)
+
+        defer { timeoutWorkItem.cancel() }
+        do {
+            try await startupGate.wait()
+            try Task.checkCancellation()
+        } catch {
+            newListener.cancel()
+            if listener === newListener {
+                listener = nil
+            }
+            debugLog("Failed to start server: \(error)")
+            throw error
         }
     }
 

--- a/MacHost/Tests/SideScreenTests/StreamingServerStartupTests.swift
+++ b/MacHost/Tests/SideScreenTests/StreamingServerStartupTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Network
+import XCTest
+@testable import SideScreen
+
+final class StreamingServerStartupTests: XCTestCase {
+    private enum TestError: Error, Equatable {
+        case first
+        case second
+    }
+
+    func testStartupGateKeepsFirstResultBeforeWaiterArrives() async throws {
+        let gate = ListenerStartupGate()
+
+        gate.resolve(.success(()))
+        gate.resolve(.failure(TestError.second))
+
+        try await gate.wait()
+    }
+
+    func testStartupGateResumesWaiterOnlyOnceWithFirstFailure() async {
+        let gate = ListenerStartupGate()
+        let waiter = Task {
+            try await gate.wait()
+        }
+
+        await Task.yield()
+        gate.resolve(.failure(TestError.first))
+        gate.resolve(.success(()))
+
+        do {
+            try await waiter.value
+            XCTFail("Expected the first startup result to win")
+        } catch {
+            XCTAssertEqual(error as? TestError, .first)
+        }
+    }
+
+    func testStartupGateCancellationResumesWaiter() async {
+        let gate = ListenerStartupGate()
+        let waiter = Task {
+            try await gate.wait()
+        }
+
+        await Task.yield()
+        waiter.cancel()
+
+        do {
+            try await waiter.value
+            XCTFail("Expected cancellation to end the startup wait")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
+
+    func testStartupGateTimeoutPreservesLastWaitingError() async {
+        let gate = ListenerStartupGate()
+        gate.noteWaitingError(NWError.posix(.ENETDOWN))
+        gate.resolveTimeout(port: 54_321)
+
+        do {
+            try await gate.wait()
+            XCTFail("Expected startup to time out")
+        } catch let error as StreamingServerStartError {
+            guard case .startupTimedOut(let port, let lastWaitingError) = error else {
+                return XCTFail("Expected startupTimedOut, got \(error)")
+            }
+            XCTAssertEqual(port, 54_321)
+            guard let networkError = lastWaitingError as? NWError,
+                  case .posix(.ENETDOWN) = networkError else {
+                return XCTFail("Expected the last waiting error to be preserved")
+            }
+        } catch {
+            XCTFail("Expected StreamingServerStartError, got \(error)")
+        }
+    }
+
+    func testStartReturnsOnlyAfterListenerIsReady() async throws {
+        let server = StreamingServer(port: 0)
+        defer { server.stop() }
+
+        try await server.start()
+        XCTAssertNotNil(server.boundPort)
+    }
+
+    func testStartPropagatesPortConflict() async throws {
+        let blocker = try NWListener(
+            using: .tcp,
+            on: NWEndpoint.Port(integerLiteral: 0)
+        )
+        let blockerGate = ListenerStartupGate()
+        blocker.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                blockerGate.resolve(.success(()))
+            case .failed(let error):
+                blockerGate.resolve(.failure(error))
+            case .cancelled:
+                blockerGate.resolve(.failure(CancellationError()))
+            default:
+                break
+            }
+        }
+        blocker.newConnectionHandler = { connection in
+            connection.cancel()
+        }
+        blocker.start(queue: DispatchQueue(label: "StreamingServerStartupTests.blocker"))
+        defer { blocker.cancel() }
+        try await blockerGate.wait()
+
+        guard let occupiedPort = blocker.port?.rawValue else {
+            return XCTFail("Ready listener did not expose its assigned port")
+        }
+
+        let server = StreamingServer(port: occupiedPort)
+        defer { server.stop() }
+        let startTime = Date()
+
+        do {
+            try await server.start()
+            XCTFail("Expected startup to fail while another listener owns the port")
+        } catch let error as StreamingServerStartError {
+            guard case .listenerFailed(let port, _) = error else {
+                return XCTFail("Expected listenerFailed, got \(error)")
+            }
+            XCTAssertEqual(port, occupiedPort)
+            XCTAssertTrue(error.localizedDescription.contains(String(occupiedPort)))
+            XCTAssertLessThan(Date().timeIntervalSince(startTime), 2)
+        } catch {
+            XCTFail("Expected StreamingServerStartError, got \(error)")
+        }
+    }
+
+    func testStopReleasesPortForFreshServer() async throws {
+        let firstServer = StreamingServer(port: 0)
+        try await firstServer.start()
+        guard let port = firstServer.boundPort else {
+            firstServer.stop()
+            return XCTFail("Ready listener did not expose its assigned port")
+        }
+        firstServer.stop()
+
+        let deadline = Date().addingTimeInterval(2)
+        var lastError: Error?
+        repeat {
+            let restartedServer = StreamingServer(port: port)
+            do {
+                try await restartedServer.start(startupTimeout: 0.5)
+                restartedServer.stop()
+                return
+            } catch {
+                restartedServer.stop()
+                lastError = error
+                guard isAddressInUse(error), Date() < deadline else {
+                    return XCTFail("Could not restart on released port \(port): \(error)")
+                }
+                try await Task.sleep(nanoseconds: 50_000_000)
+            }
+        } while Date() < deadline
+
+        XCTFail("Port \(port) was not released in time: \(String(describing: lastError))")
+    }
+
+    private func isAddressInUse(_ error: Error) -> Bool {
+        guard let startError = error as? StreamingServerStartError,
+              case .listenerFailed(_, let underlying) = startError,
+              let networkError = underlying as? NWError,
+              case .posix(.EADDRINUSE) = networkError else {
+            return false
+        }
+        return true
+    }
+}


### PR DESCRIPTION
## Problem

After sleep/wake or other restart paths, the Mac host could continue setting up capture and the virtual display before its TCP listener was actually ready. StreamingServer.start() returned immediately after scheduling NWListener startup, while later listener failures were only logged.

This created a startup race: a failed or delayed bind could leave partially initialized resources and make the host appear started even though the tablet could not receive a stream, presenting as a black screen. Rapid or overlapping start requests could make that lifecycle less predictable.

## Changes

- Make StreamingServer.start() async and throwing, and return only after NWListener reaches ready.
- Propagate listener construction and terminal listener failures to the caller.
- Fail fast for an occupied port, while retaining transient waiting errors for timeout diagnostics.
- Add a bounded startup timeout and cancellation handling.
- Use an exact-once startup gate so callback ordering cannot leak or resume a continuation twice.
- Cancel and clear a partially started listener on every startup failure.
- Await server readiness in AppDelegate before capture setup is considered complete.
- Prevent overlapping start operations and clean up partial server, capture, and display resources when startup fails.
- Add seven focused lifecycle regression tests covering readiness, port conflicts, cancellation, timeout diagnostics, exact-once completion, and port release/rebind behavior.

## Validation

Local environment:
- macOS 15.7.5
- Xcode 26.3 (Build 17C529)
- Apple Swift 6.2.4

Automated:
- swift test: 42 tests passed, 0 failures.
- The seven new startup tests were repeated for five additional runs: 35/35 passed.
- Release build with warnings treated as errors passed.

Real-device verification:
- Normal tablet connection works.
- Sleep and wake reconnect works.
- Rapid/concurrent start attempts behave correctly.
- Port conflict followed by release and retry recovers correctly.
- No tablet-side changes were required.