### PR TITLE
fix(android): preserve connections across rotation

### DIFF
--- a/AndroidClient/app/src/main/AndroidManifest.xml
+++ b/AndroidClient/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         <activity
             android:name=".MainActivity"
             android:screenOrientation="fullUser"
-            android:configChanges="orientation|screenSize|screenLayout"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
@@ -36,6 +36,7 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.slider.Slider
 import com.google.android.material.switchmaterial.SwitchMaterial
 import com.sidescreen.app.databinding.ActivityMainBinding
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.ensureActive
@@ -1249,6 +1250,8 @@ class MainActivity : AppCompatActivity() {
                 // listener (above) right after handshake OK — not here. This line
                 // would otherwise run AFTER the receive loop exits, i.e. AFTER
                 // disconnect, incorrectly transitioning back to CONNECTED.
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: StreamClient.WirelessConnectError) {
                 runOnUiThread {
                     wirelessController.onConnectError(e)
@@ -1381,6 +1384,8 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 streamClient?.connect()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 val errorMessage =
                     when {

--- a/AndroidClient/app/src/test/java/com/sidescreen/app/MainActivityManifestTest.kt
+++ b/AndroidClient/app/src/test/java/com/sidescreen/app/MainActivityManifestTest.kt
@@ -1,0 +1,46 @@
+package com.sidescreen.app
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+class MainActivityManifestTest {
+    @Test
+    fun handlesAllRotationRelatedSizeChangesWithoutActivityRecreation() {
+        val manifest = findManifest()
+        val document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(manifest)
+        val activities = document.getElementsByTagName("activity")
+        val mainActivity =
+            (0 until activities.length)
+                .map { activities.item(it) }
+                .first { it.attributes.getNamedItem("android:name")?.nodeValue == ".MainActivity" }
+        val handledChanges =
+            mainActivity.attributes
+                .getNamedItem("android:configChanges")
+                .nodeValue
+                .split('|')
+                .toSet()
+        val requiredChanges =
+            setOf(
+                "orientation",
+                "screenSize",
+                "screenLayout",
+                "smallestScreenSize",
+            )
+
+        assertTrue(
+            "MainActivity must handle all rotation-related size changes to keep streaming alive",
+            handledChanges.containsAll(requiredChanges),
+        )
+    }
+
+    private fun findManifest(): File {
+        val workingDirectory = File(System.getProperty("user.dir") ?: error("user.dir is not set"))
+        return listOf(
+            workingDirectory.resolve("app/src/main/AndroidManifest.xml"),
+            workingDirectory.resolve("src/main/AndroidManifest.xml"),
+        ).firstOrNull(File::isFile)
+            ?: error("AndroidManifest.xml not found from $workingDirectory")
+    }
+}


### PR DESCRIPTION
## Description

Prevent Android display rotations from recreating `MainActivity` for a size change that the app already handles. Recreation destroys the activity lifecycle, cancels the lifecycle-scoped stream, and can surface the misleading `Connection failed: Job was cancelled` dialog.

## Reported Device and Reproduction

This change is based on a user report from a **Samsung Galaxy Z Fold8**:

- Portrait mode: Side Screen connects and streams normally.
- Landscape mode: the connection fails while starting.
- Visible error: `Connection failed: Job was cancelled`.
- The supplied screenshot shows the Android client on the USB tab.

Reproduction reported by the user:

1. Start Side Screen on the Mac and connect the Galaxy Z Fold8.
2. Keep the phone in portrait orientation and connect: the connection succeeds.
3. Rotate or start the phone in landscape orientation and connect: the connection is cancelled and the error dialog appears.

The portrait-only success is an important clue: the Mac server and ADB tunnel are reachable, while the failure coincides with the Android configuration transition into landscape.

## Root Cause

`MainActivity` starts both USB and wireless connections in `lifecycleScope`. Android cancels every coroutine in that scope when the activity is destroyed.

Rotating a foldable or large-screen device can change `orientation`, `screenSize`, `screenLayout`, and `smallestScreenSize`. Side Screen declared handling for the first three configuration changes but omitted `smallestScreenSize`. On a device that reports this significant size change, Android can recreate `MainActivity` during the landscape transition. That recreation cancels the active connection coroutine.

The USB connection handler then caught the resulting `CancellationException` as a generic `Exception` and displayed its message as a network failure. This is why the user saw `Connection failed: Job was cancelled`, even though the cancellation originated from the activity lifecycle rather than ADB, the USB cable, or the Mac server.

Android documents `screenSize|smallestScreenSize|orientation|screenLayout` as the complete set needed to opt out of Activity recreation for size-based configuration changes.

## How This Fix Resolves It

- Add `smallestScreenSize` to `MainActivity` configuration handling. Android can deliver the landscape size change to the existing activity instead of recreating it, so the active stream and its lifecycle scope remain alive.
- Rethrow `CancellationException` from both USB and wireless connection coroutines. Legitimate lifecycle cancellation is no longer converted into a misleading connection-error dialog.
- Add a regression test that verifies the manifest covers all four rotation-related size changes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issue

No existing issue found.

## Testing

The regression test was first run against the previous manifest and failed because `smallestScreenSize` was absent. It passes after this change.

- `./gradlew testDebugUnitTest assembleDebug`
- `ktlint 1.1.1 app/src/main/java/**/*.kt app/src/test/java/**/*.kt`
- Inspected the built debug APK manifest with `aapt2`; `MainActivity` contains the merged config-change mask `0x00000d80`.

- [ ] Retested on the reported Galaxy Z Fold8 (the device was not attached to this development environment)
- [ ] Retested the USB connection on physical hardware

## Screenshots

The reported error dialog reads `Connection failed: Job was cancelled`. There is no UI change in this PR.

## Checklist

- [x] My code follows the project coding standards
- [x] Automated tests and the debug build pass
- [x] No documentation update is required
- [x] My changes do not introduce new warnings
- [x] The configuration behavior is covered by a regression test

## Additional Notes

This is intentionally a narrow lifecycle/configuration fix. Review on the reported Galaxy Z Fold8 is recommended to confirm both portrait and landscape USB connection paths on physical hardware.

Android reference: https://developer.android.com/topic/architecture/views/resources/runtime-changes-views#handle-size-based-config-changes