### PR TITLE
fix: bound stream size by what the client can actually decode

### DIFF
--- a/AndroidClient/app/src/main/java/com/sidescreen/app/CodecCapabilities.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/CodecCapabilities.kt
@@ -32,7 +32,7 @@ object CodecCapabilities {
      * Usable *hardware* decoder for [mime]: not an encoder, not the (too slow
      * for real-time mirroring) Google software implementation, and for HEVC
      * not one of the vendor implementations that never render to a Surface.
-     * Shared by [hasHevcDecoder] and [maxDecodeSize] so the classification
+     * Shared by [hasHevcDecoder] and [nominalMaxDecodeSize] so the classification
      * cannot drift between them. Same hardware/software split
      * VideoDecoder.findBestDecoder uses.
      */
@@ -64,38 +64,86 @@ object CodecCapabilities {
     val streamMime: String
         get() = if (hasHevcDecoder) MediaFormat.MIMETYPE_VIDEO_HEVC else MediaFormat.MIMETYPE_VIDEO_AVC
 
-    private val maxDecodeSizeCache = HashMap<String, Pair<Int, Int>?>()
+    private val nominalSizeCache = HashMap<String, Pair<Int, Int>?>()
 
     /**
-     * Upper decode bounds (width × height) of the largest usable *hardware*
-     * decoder for [mime] — the software fallback is too slow for real-time
-     * mirroring to count as a ceiling. Null when nothing usable exists or the
-     * probe fails (legacy behavior: no limit advertised to the Mac).
-     * Cached per mime: enumerating MediaCodecList is not cheap and the answer
-     * never changes at runtime (same reason hasHevcDecoder is lazy).
+     * The `size` limit the largest usable *hardware* decoder for [mime] advertises. Null when
+     * nothing usable exists or the probe fails (legacy behavior: advertise no limit to the Mac).
+     * Cached per mime: enumerating MediaCodecList is not cheap and the answer never changes at
+     * runtime (same reason hasHevcDecoder is lazy).
+     *
+     * Nominal, not achievable. Vendor decoders routinely advertise a `size` far above what their
+     * `blocks-per-second` budget can sustain, and configuring above that budget succeeds and then
+     * silently never outputs a frame. Prefer [maxStreamSize] for anything the Mac will encode.
      */
-    fun maxDecodeSize(mime: String): Pair<Int, Int>? =
-        synchronized(maxDecodeSizeCache) {
-            maxDecodeSizeCache.getOrPut(mime.lowercase()) { probeMaxDecodeSize(mime) }
+    fun nominalMaxDecodeSize(mime: String): Pair<Int, Int>? =
+        synchronized(nominalSizeCache) {
+            nominalSizeCache.getOrPut(mime.lowercase()) { probeNominalSize(mime) }
         }
 
-    private fun probeMaxDecodeSize(mime: String): Pair<Int, Int>? =
+    private fun probeNominalSize(mime: String): Pair<Int, Int>? =
+        bestVideoCapabilities(mime)?.let { it.supportedWidths.upper to it.supportedHeights.upper }
+
+    /** Video capabilities of the largest usable hardware decoder for [mime]. */
+    private fun bestVideoCapabilities(mime: String): MediaCodecInfo.VideoCapabilities? =
         try {
             MediaCodecList(MediaCodecList.ALL_CODECS)
                 .codecInfos
                 .asSequence()
                 .filter { isUsableHardwareDecoder(it, mime) }
                 .mapNotNull { info ->
-                    val videoCaps =
-                        try {
-                            info.getCapabilitiesForType(mime).videoCapabilities
-                        } catch (_: Exception) {
-                            null
-                        }
-                    videoCaps?.let { it.supportedWidths.upper to it.supportedHeights.upper }
-                }
-                .maxByOrNull { (w, h) -> w.toLong() * h.toLong() }
+                    try {
+                        info.getCapabilitiesForType(mime).videoCapabilities
+                    } catch (_: Exception) {
+                        null
+                    }
+                }.maxByOrNull { it.supportedWidths.upper.toLong() * it.supportedHeights.upper.toLong() }
         } catch (_: Exception) {
             null
         }
+
+    private const val BLOCK_ALIGN = 16
+
+    /**
+     * The largest frame the Mac should ever encode for us: no larger than the panel can show, and
+     * within what the decoder sustains at [fps]. Null when no usable decoder exists or the probe
+     * fails, which leaves the legacy "advertise nothing" behavior in place.
+     *
+     * The panel is the upper bound because anything above it is downscaled on arrival anyway, so
+     * spending decode budget there buys nothing. [MediaCodecInfo.VideoCapabilities.areSizeAndRateSupported]
+     * is the check that consults `blocks-per-second`, which [nominalMaxDecodeSize] misses. Shrinks
+     * stepwise rather than solving directly because the budget counts aligned macroblocks.
+     */
+    fun maxStreamSize(
+        mime: String,
+        panelWidth: Int,
+        panelHeight: Int,
+        fps: Int,
+    ): Pair<Int, Int>? {
+        if (panelWidth <= 0 || panelHeight <= 0) return null
+        val caps = bestVideoCapabilities(mime) ?: return null
+        val rate = fps.coerceAtLeast(1).toDouble()
+
+        var w = panelWidth.coerceAtMost(caps.supportedWidths.upper)
+        var h = panelHeight.coerceAtMost(caps.supportedHeights.upper)
+        val aspect = panelWidth.toDouble() / panelHeight.toDouble()
+
+        repeat(40) {
+            val alignedW = (w / BLOCK_ALIGN) * BLOCK_ALIGN
+            val alignedH = (h / BLOCK_ALIGN) * BLOCK_ALIGN
+            if (alignedW < 256 || alignedH < 256) return null
+            val supported =
+                try {
+                    caps.areSizeAndRateSupported(alignedW, alignedH, rate)
+                } catch (_: IllegalArgumentException) {
+                    false
+                } catch (_: Exception) {
+                    return null
+                }
+            if (supported) return alignedW to alignedH
+            w = (w * 0.95).toInt()
+            h = (w / aspect).toInt()
+        }
+        return null
+    }
 }

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
@@ -988,7 +988,11 @@ class MainActivity : AppCompatActivity() {
                 // Black screen with live stats: tell the user why instead of
                 // staying silent (issue #41). Toast renders above the (black)
                 // SurfaceView; the settings panel is hidden while streaming.
-                val cap = CodecCapabilities.maxDecodeSize(mime)
+                // The sustainable size, not the decoder's advertised one — that is typically far
+                // above anything it can really output, which made this message actively misleading.
+                val panel = PanelGeometry.of(displayObj)
+                val cap =
+                    panel?.let { CodecCapabilities.maxStreamSize(mime, it.width, it.height, it.refreshHz) }
                 runOnUiThread {
                     val capText = cap?.let { " (max ~${it.first}×${it.second})" } ?: ""
                     android.widget.Toast
@@ -1270,7 +1274,7 @@ class MainActivity : AppCompatActivity() {
             try {
                 log("Connecting to $host:$port...")
 
-                streamClient = StreamClient(host, port)
+                streamClient = StreamClient(host, port, applicationContext)
                 streamClient?.onFrameReceived = { frameData, frameSize, timestamp, isKeyframe ->
                     val dec = videoDecoder
                     if (dec != null) {

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/PanelGeometry.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/PanelGeometry.kt
@@ -1,0 +1,42 @@
+package com.sidescreen.app
+
+import android.content.Context
+import android.hardware.display.DisplayManager
+import android.view.Display
+
+/** Native panel size in landscape orientation, plus the fastest mode it can present. */
+data class PanelGeometry(
+    val width: Int,
+    val height: Int,
+    val refreshHz: Int,
+) {
+    companion object {
+        /**
+         * [Display.Mode.physicalWidth] and [Display.Mode.physicalHeight] report the panel in its
+         * natural orientation whatever the current rotation, so this answer is stable when the
+         * tablet is turned. Null when the display or its mode is unavailable.
+         */
+        fun of(display: Display?): PanelGeometry? {
+            val mode = display?.mode ?: return null
+            val w = maxOf(mode.physicalWidth, mode.physicalHeight)
+            val h = minOf(mode.physicalWidth, mode.physicalHeight)
+            if (w <= 0 || h <= 0) return null
+            // Peak rate over all modes, not the current one: a panel parked at 60 can still be
+            // asked for 90, and decoding faster than the peak only burns throughput budget.
+            val hz =
+                display.supportedModes
+                    ?.maxOfOrNull { it.refreshRate }
+                    ?.toInt()
+                    ?: display.refreshRate.toInt()
+            return PanelGeometry(w, h, hz.coerceIn(24, 240))
+        }
+
+        fun ofDefaultDisplay(context: Context): PanelGeometry? =
+            try {
+                val dm = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+                of(dm.getDisplay(Display.DEFAULT_DISPLAY))
+            } catch (_: Exception) {
+                null
+            }
+    }
+}

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/StreamClient.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/StreamClient.kt
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
 class StreamClient(
     private val host: String,
     private val port: Int,
-    private val context: Context? = null,
+    private val context: Context,
 ) {
     private var socket: Socket? = null
     private var inputStream: DataInputStream? = null
@@ -180,14 +180,12 @@ class StreamClient(
         try {
             val sock = Socket()
             sock.tcpNoDelay = true
+            val cm = context.getSystemService(ConnectivityManager::class.java)
             val wifiNetwork =
-                context?.let { ctx ->
-                    val cm = ctx.getSystemService(ConnectivityManager::class.java)
-                    cm.allNetworks.firstOrNull { net ->
-                        val caps = cm.getNetworkCapabilities(net)
-                        caps?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true &&
-                            caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                    }
+                cm.allNetworks.firstOrNull { net ->
+                    val caps = cm.getNetworkCapabilities(net)
+                    caps?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true &&
+                        caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
                 }
             if (wifiNetwork != null) {
                 Log.i(TAG, "openWirelessSocket: binding socket to WiFi network $wifiNetwork")
@@ -394,7 +392,15 @@ class StreamClient(
     }
 
     private fun advertiseDecoderLimits() {
-        val (maxW, maxH) = CodecCapabilities.maxDecodeSize(CodecCapabilities.streamMime) ?: return
+        val mime = CodecCapabilities.streamMime
+        val panel = PanelGeometry.ofDefaultDisplay(context)
+        // Nominal limit only as a fallback: it ignores blocks-per-second, so on most devices it is
+        // far too high to protect anything.
+        val limit =
+            panel?.let { CodecCapabilities.maxStreamSize(mime, it.width, it.height, it.refreshHz) }
+                ?: CodecCapabilities.nominalMaxDecodeSize(mime)
+                ?: return
+        val (maxW, maxH) = limit
         val w = maxW.coerceAtMost(16383)
         val h = maxH.coerceAtMost(16383)
         if (w < 256 || h < 256) return
@@ -408,7 +414,7 @@ class StreamClient(
             out.writeByte(0x80 or ((h shr 7) and 0x7F))
             out.writeByte(0x80 or (h and 0x7F))
             out.flush()
-            diagLog("Advertised decoder limit ${w}x$h for ${CodecCapabilities.streamMime}")
+            diagLog("Advertised stream limit ${w}x$h for $mime (panel=$panel)")
         }
     }
 
@@ -693,7 +699,10 @@ class StreamClient(
 
     companion object {
         private const val TAG = "StreamClient"
-        private const val MAX_FRAME_SIZE = 5 * 1024 * 1024 // 5MB
+
+        // Only a desync guard — acquireBuffer allocates the real frame size, so a generous bound
+        // costs nothing. Must clear a keyframe at panel resolution and the highest offered bitrate.
+        private const val MAX_FRAME_SIZE = 32 * 1024 * 1024 // 32MB
         private const val PAIRING_READ_TIMEOUT_MS = 10_000
         private const val KEYFRAME_REQUEST_INTERVAL_NS = 500_000_000L
         private const val KEYFRAME_STALE_INTERVAL_NS = 1_500_000_000L

--- a/MacHost/Sources/CodecLimits.swift
+++ b/MacHost/Sources/CodecLimits.swift
@@ -37,4 +37,19 @@ enum CodecLimits {
     static func clampForAvc(width: Int, height: Int) -> (width: Int, height: Int) {
         clamp(width: width, height: height, maxWidth: avcMaxWidth, maxHeight: avcMaxHeight)
     }
+
+    /// Clamp into a client-reported ceiling, transposing the box when its
+    /// orientation differs from the capture's. Clients report the ceiling in
+    /// their panel's natural orientation, but it stands for a macroblock area
+    /// budget, which is indifferent to which side is longer.
+    static func clampToClientLimit(
+        width: Int,
+        height: Int,
+        limit: (width: Int, height: Int)
+    ) -> (width: Int, height: Int) {
+        let box = (height > width) == (limit.height > limit.width)
+            ? limit
+            : (width: limit.height, height: limit.width)
+        return clamp(width: width, height: height, maxWidth: box.width, maxHeight: box.height)
+    }
 }

--- a/MacHost/Sources/ScreenCapture.swift
+++ b/MacHost/Sources/ScreenCapture.swift
@@ -136,21 +136,25 @@ class ScreenCapture {
     /// Codec for the current encode session. Switching restarts the stream.
     private(set) var codec: StreamCodec = .hevc
 
-    /// Decoder ceiling reported by the connected client (issue #41). Nil for
-    /// legacy clients that report nothing.
+    /// Largest frame the connected client wants to receive (issue #41): the
+    /// smaller of its panel size and what its decoder can sustain at the panel
+    /// refresh rate. Nil for legacy clients that report nothing.
     private var clientDecodeLimit: (width: Int, height: Int)?
 
     /// Encode dimensions for a codec: physical display pixels, clamped to the
-    /// client's reported decoder limit when known, else to the conservative
-    /// AVC floor when streaming H.264. SCStream/CGDisplayStream scale the
-    /// capture into this size, so no virtual-display change is needed.
+    /// client's reported ceiling when known, else to the conservative AVC floor
+    /// when streaming H.264. SCStream/CGDisplayStream scale the capture into
+    /// this size, so no virtual-display change is needed.
+    ///
+    /// This is what makes HiDPI usable on a tablet: macOS renders at 2x, SCStream
+    /// downsamples to the client's ceiling before encode, and the client decodes
+    /// a frame it can sustain — sharper than a 1x capture of the same size.
     func encodeSize(for codec: StreamCodec) -> (width: Int, height: Int) {
         let phys = (displayWidth, displayHeight)
         // A reported limit is authoritative for both codecs: it is what the
         // client's own MediaCodec claims it can decode.
         if let limit = clientDecodeLimit {
-            return CodecLimits.clamp(width: phys.0, height: phys.1,
-                                     maxWidth: limit.width, maxHeight: limit.height)
+            return CodecLimits.clampToClientLimit(width: phys.0, height: phys.1, limit: limit)
         }
         switch codec {
         case .hevc: return phys

--- a/MacHost/Sources/SettingsWindow.swift
+++ b/MacHost/Sources/SettingsWindow.swift
@@ -1284,7 +1284,7 @@ class DisplaySettings: ObservableObject {
 
     static let resolutionGroups: [ResolutionGroup] = [
         ResolutionGroup(name: "16:10", ratio: "Widescreen", resolutions: [
-            "1280x800", "1440x900", "1680x1050", "1920x1200", "2560x1600"
+            "1280x800", "1440x900", "1680x1050", "1920x1200", "2304x1440", "2560x1600"
         ]),
         ResolutionGroup(name: "16:9", ratio: "HD/4K", resolutions: [
             "1280x720", "1366x768", "1600x900", "1920x1080", "2560x1440", "3840x2160"

--- a/MacHost/Tests/SideScreenTests/CodecLimitsTests.swift
+++ b/MacHost/Tests/SideScreenTests/CodecLimitsTests.swift
@@ -62,6 +62,38 @@ final class CodecLimitsTests: XCTestCase {
         XCTAssertEqual(r.height, 1200)
     }
 
+    // MARK: - Orientation-aware client limit
+
+    func testPortraitCaptureIsMeasuredAgainstTransposedLimit() {
+        // A portrait virtual display against a landscape-reported ceiling. Without
+        // transposing, 1440x2304 would shrink to 900x1440 despite the client
+        // displaying 1440x2304 natively.
+        let r = CodecLimits.clampToClientLimit(width: 1440, height: 2304, limit: (width: 2304, height: 1440))
+        XCTAssertEqual(r.width, 1440)
+        XCTAssertEqual(r.height, 2304)
+    }
+
+    func testLandscapeCaptureUsesLimitAsReported() {
+        let r = CodecLimits.clampToClientLimit(width: 2304, height: 1440, limit: (width: 2304, height: 1440))
+        XCTAssertEqual(r.width, 2304)
+        XCTAssertEqual(r.height, 1440)
+    }
+
+    func testTransposedLimitStillClampsOversizeCapture() {
+        // HiDPI portrait: 2880x4608 physical against the same landscape ceiling.
+        let r = CodecLimits.clampToClientLimit(width: 2880, height: 4608, limit: (width: 2304, height: 1440))
+        XCTAssertLessThanOrEqual(r.width, 1440)
+        XCTAssertLessThanOrEqual(r.height, 2304)
+        XCTAssertEqual(r.width % 16, 0)
+        XCTAssertEqual(r.height % 16, 0)
+    }
+
+    func testSquareCaptureIsUnaffectedByTransposition() {
+        let r = CodecLimits.clampToClientLimit(width: 1600, height: 1600, limit: (width: 2304, height: 1440))
+        XCTAssertLessThanOrEqual(r.height, 1440)
+        XCTAssertEqual(r.width, r.height)
+    }
+
     func testClientLimitPreservesAspectRatio() {
         let r = CodecLimits.clamp(width: 3840, height: 2400, maxWidth: 1920, maxHeight: 1920)
         // 16:10 in, ~16:10 out (within 16-alignment error)


### PR DESCRIPTION
## Problem

The client advertises its decoder ceiling from `MediaCodecInfo.VideoCapabilities.supportedWidths/Heights.upper`. That is the `size` limit out of the vendor's `media_codecs.xml`, and vendors routinely overstate it. The constraint that actually binds is `blocks-per-second`, which that API never reports.

Measured on a Galaxy Tab S9 FE (Exynos, 2304x1440 90 Hz panel):

```
<Limit name="size"              min="64x64" max="8192x8192" />
<Limit name="blocks-per-second" min="1"     max="1224000"   />
```

So the client advertised 8192x8192 and the Mac's clamp in `ScreenCapture.encodeSize` never engaged. The real budget at 16x16 blocks is about 1.22M blocks/s:

| Stream | Blocks/frame | @60fps | Sustainable |
|---|---|---|---|
| 1920x1200 | 9,000 | 540,000 | yes |
| 2304x1440 | 12,960 | 777,600 | yes |
| 2560x1600 | 16,000 | 960,000 | yes |
| 4608x2880 (2304x1440 HiDPI) | 51,840 | 3,110,400 | no, 2.5x over |

`MediaCodec.configure()` accepts anything inside 8192x8192. Above the throughput budget the decoder starts, accepts input buffers, and never outputs a frame. That is the black screen in #41. HiDPI made it certain rather than likely, because it doubles both axes.

There is a second wall behind that one. `MAX_FRAME_SIZE` in `StreamClient` was 5MB, and exceeding it throws `IOException` and drops the connection. At the higher bitrate presets a keyframe above 1080p clears 5MB, so the same resolution bump could show up as a disconnect instead of a black screen.

## Fix

Bound the stream by what the client can display and decode, rather than by a number the decoder made up.

- **`CodecCapabilities.maxStreamSize()`** starts at the panel size and shrinks until `areSizeAndRateSupported()` passes. That is the API that consults `blocks-per-second`. The panel is the upper bound because the client downscales anything larger on arrival, so decode budget spent above it buys nothing.
- **`PanelGeometry`** reads the true panel from `Display.Mode.physicalWidth/Height`, which does not change with rotation, and the peak rate across `supportedModes`.
- **`MAX_FRAME_SIZE` goes from 5MB to 32MB.** It is only a desync guard. `acquireBuffer` allocates the real frame size, so a generous bound costs nothing in steady state.
- **`CodecLimits.clampToClientLimit()`** transposes the ceiling when the capture's orientation differs from the client's. The limit stands for a macroblock area budget, which does not care which side is longer, so a portrait display measured against a landscape box was losing pixels for no reason.
- **The decoder-stall toast** used the nominal limit. The one message a user sees when this fails read "max ~8192x8192". It now reports the sustainable size.
- **`StreamClient` requires a `Context`.** The USB path constructed it without one and skipped the panel probe. The compiler now prevents that.

I renamed `maxDecodeSize` to `nominalMaxDecodeSize` so the trap is visible at the call site.

## Why this is general

Nothing here keys off a model or vendor. An inflated `size` limit sitting next to a real `blocks-per-second` budget is how `media_codecs.xml` normally reads on Exynos, MediaTek and Qualcomm, so any device whose panel outruns its decoder at the requested frame rate hit this. Devices that report nothing usable keep their old behavior through the existing fallback.

Bounding at the panel also makes HiDPI usable on a tablet. macOS renders at 2x, SCStream downsamples to the panel size before encode, and the client decodes a frame it can sustain. That is sharper than a 1x capture of the same size, because it is supersampled.

## Verification

Measured on-device before and after, from a side-by-side build:

```
panel = 2304x1440 @ 90Hz, mime = video/hevc

nominal (old, advertised) = (8192, 8192)
maxStreamSize @ 60fps     = (2304, 1440)
maxStreamSize @ 90fps     = (2304, 1440)
maxStreamSize @ 120fps    = (1968, 1232)   <- backs off, 120fps exceeds the budget
```

The 120 fps row is the one I would check first. 2304x1440 at 120 fps needs 1,555,200 blocks/s against a 1,224,000 budget, so it steps down instead of going black.

I also confirmed that HiDPI virtual-display creation was never the broken part. A small test program against `CGVirtualDisplay` reproduces `2304x1440 logical @ 4608x2880 pixels, backingScaleFactor 2.0` correctly. The failure was always downstream, at encode size.

macOS builds clean and passes 39/39 tests, including 4 new orientation cases in `CodecLimitsTests`. Android compiles clean, unit tests pass, ktlint is clean.

## A decoder-sizing bug this fixes on the way past

The display-config message is not only what the client's overlay renders. It is also what the client sizes its decoder from:

```kotlin
// VideoDecoder.kt, decoder selection
val supported     = videoCaps.isSizeSupported(width, height)
val rateSupported = videoCaps.areSizeAndRateSupported(width, height, targetRate)

// VideoDecoder.kt, configuration
MediaFormat.createVideoFormat(mime, currentWidth, currentHeight)
```

With HiDPI on, `AppDelegate` deliberately sends the logical resolution so the overlay matches the Mac's dropdown, while the stream is the doubled one. Observed on 0.11.2 with HiDPI at 2560x1600:

```
Sent display config:  2560x1600      <- client sizes its decoder from this
Stream configured:    5120x3200      <- client is actually fed this
Client decoder limit: 8192x8192
```

So the client asks "can you decode 2560x1600 at 90fps", is told yes, picks a decoder on that basis, and is then handed 5120x3200. The only throughput check that exists on the client runs against a resolution that is not the stream. MediaCodec does adapt afterwards from the SPS, but selection and the capability check have already happened by then.

This PR corrects that wherever the clamp engages, through the existing branch at `AppDelegate.swift:656`: once `enc != physical`, the real encoded size goes out and the decoder is configured for the stream it will receive.

One narrow gap remains, and this PR does not close it: HiDPI on a device that genuinely can decode the doubled frame, where the clamp stays inactive and the halved number still goes out. Fixing that properly means always sending the encoded size and carrying the desktop geometry in a separate field for the overlay. That is a protocol change and belongs in its own PR.

## Two things I left alone

Both are deliberate choices with UI behind them, so they seemed like yours to make.

The default bitrate of 1000 Mbps sits above the declared `bitrate range 1-80000000` (80 Mbps) on this class of decoder. AOSP does not enforce that range in `areSizeAndRateSupported`, so this fix does not catch it. A lower default, or clamping against the decoder's declared bitrate, would.

`resetToDefaults()` sets 120 Hz, which is higher than many tablet panels can show. Frame rate trades against resolution in the same budget, as the table above shows, so a default above the panel's peak costs resolution without anyone seeing why.

