### PR TITLE
feat(mac): register a HiDPI mode ladder so macOS offers scaling

### DIFF
--- a/MacHost/Sources/AppDelegate.swift
+++ b/MacHost/Sources/AppDelegate.swift
@@ -672,6 +672,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 self.streamingServer?.setDesktopSize(width: size.width, height: size.height)
                 self.streamingServer?.setDisplaySize(width: enc.width, height: enc.height, rotation: self.settings.rotation, flipHorizontal: self.settings.flipHorizontal, flipVertical: self.settings.flipVertical)
             }
+            // Switching the scaling rung in System Settings changes the display's mode under a
+            // live session. The encode setup follows only when the new mode actually changes the
+            // encode size; the desktop size always does, since it is the rung the user picked.
+            virtualDisplayManager?.onDisplayModeChanged = { [weak self] logicalWidth, logicalHeight in
+                guard let self = self, let capture = self.screenCapture else { return }
+                let enc = capture.displayModeChanged()
+                self.streamingServer?.setDesktopSize(width: logicalWidth, height: logicalHeight)
+                self.streamingServer?.setDisplaySize(
+                    width: enc.width,
+                    height: enc.height,
+                    rotation: self.settings.rotation,
+                    flipHorizontal: self.settings.flipHorizontal,
+                    flipVertical: self.settings.flipVertical
+                )
+                self.streamingServer?.sendDisplaySize()
+            }
             streamingServer?.onKeyframeRequested = { [weak self] force in
                 self?.screenCapture?.requestKeyframeOrReplayCachedFrame(force: force)
             }

--- a/MacHost/Sources/ScreenCapture.swift
+++ b/MacHost/Sources/ScreenCapture.swift
@@ -75,6 +75,10 @@ class ScreenCapture {
     private var currentFrameRate: Int = 60
 
     // Encoding pipeline state (captured by frame handler closure)
+    /// Dimensions the live encoder and SCStream were built for. A mode change alters the
+    /// display's physical size underneath both, so the old value is the only way to tell
+    /// whether the new encode size actually differs.
+    private var activeEncodeSize: (width: Int, height: Int)?
     private var encodeQueue: DispatchQueue?
     private var pendingEncodes: Int32 = 0
     private var lastPixelBuffer: CVPixelBuffer?
@@ -440,6 +444,7 @@ class ScreenCapture {
         let (width, height) = encodeSize(for: codec)
 
         encoder = VideoEncoder(width: width, height: height, codec: codec, bitrateMbps: bitrateMbps, quality: quality, gamingBoost: gamingBoost, frameRate: frameRate)
+        activeEncodeSize = (width, height)
         encoder?.onEncodedFrame = { [weak server] data, timestamp, isKeyframe in
             server?.sendFrame(data, timestamp: timestamp, isKeyframe: isKeyframe)
         }
@@ -769,6 +774,27 @@ class ScreenCapture {
         rebuildEncoder()
     }
 
+    /// Re-evaluate the encode setup after macOS switches the virtual display to another mode.
+    /// Returns the size now in force so the caller can tell the client about it.
+    ///
+    /// Most switches need no work: every rung of a HiDPI ladder shares one aspect ratio, so when
+    /// the client's ceiling is below the doubled framebuffer they all clamp to the same encode
+    /// size and SCStream's configuration stays correct. Rungs off that aspect (the fallback modes
+    /// macOS adds itself) do change it, and leaving the old configuration in place letterboxes the
+    /// picture into a frame shaped for the previous mode.
+    @discardableResult
+    func displayModeChanged() -> (width: Int, height: Int) {
+        let size = encodeSize(for: codec)
+        guard encoder != nil, let previous = activeEncodeSize else { return size }
+        guard previous != size else {
+            debugLog("Display mode changed — encode size unchanged at \(size.width)x\(size.height)")
+            return size
+        }
+        debugLog("Display mode changed — encode size \(previous.width)x\(previous.height) -> \(size.width)x\(size.height)")
+        rebuildEncoder()
+        return size
+    }
+
     private func rebuildEncoder() {
         let (width, height) = encodeSize(for: codec)
         let server = currentServer
@@ -778,6 +804,7 @@ class ScreenCapture {
         }
         newEncoder.requestKeyframe()
         encoder = newEncoder
+        activeEncodeSize = (width, height)
 
         restartStream()
     }

--- a/MacHost/Sources/VirtualDisplayManager.swift
+++ b/MacHost/Sources/VirtualDisplayManager.swift
@@ -18,6 +18,33 @@ class VirtualDisplayManager {
         return virtualDisplay != nil
     }
 
+    /// Fractions of the chosen logical size offered as HiDPI scaling steps. The chosen size stays
+    /// the top rung, so picking a resolution in this app sets the ceiling and macOS scales down
+    /// from there. Five steps matches what System Settings draws for a built-in Retina panel.
+    private static let hiDPILadderRatios: [Double] = [1.0, 0.875, 0.75, 0.625, 0.5]
+
+    /// Logical sizes to register for a HiDPI display, largest first.
+    ///
+    /// Height is derived from the scaled width so every rung keeps the chosen aspect ratio: a rung
+    /// that drifts off it would letterbox on the client. Sizes are rounded to even numbers because
+    /// the physical mode is exactly twice the logical one, and duplicates are dropped so a small
+    /// chosen resolution cannot register the same mode twice.
+    static func hiDPILogicalLadder(width: Int, height: Int) -> [(width: Int, height: Int)] {
+        guard width > 0, height > 0 else { return [] }
+        let aspect = Double(width) / Double(height)
+        var seen = Set<String>()
+        var ladder: [(width: Int, height: Int)] = []
+        for ratio in hiDPILadderRatios {
+            let w = max(2, Int((Double(width) * ratio).rounded()) & ~1)
+            let h = max(2, Int((Double(w) / aspect).rounded()) & ~1)
+            let key = "\(w)x\(h)"
+            if seen.insert(key).inserted {
+                ladder.append((width: w, height: h))
+            }
+        }
+        return ladder
+    }
+
     /// Create a virtual display with specified configuration
     /// - Parameters:
     ///   - width: Display width in pixels
@@ -65,9 +92,12 @@ class VirtualDisplayManager {
         let settings = CGVirtualDisplaySettings()
         settings.hiDPI = hiDPI ? 1 : 0
 
-        // HiDPI: anchor mode (physical) + logical mode
-        // The anchor tells macOS "this display is high-density" → unlocks HiDPI for logical mode
-        // non-HiDPI: single mode at requested resolution
+        // HiDPI: anchor mode (physical) + a ladder of logical modes.
+        // The anchor tells macOS "this display is high-density" → unlocks HiDPI for logical mode.
+        // The ladder is what System Settings turns into its "Larger Text … More Space" picker:
+        // that control is drawn from the display's desktop-usable HiDPI modes, so a single
+        // logical mode leaves the user with no scaling choice outside this app.
+        // non-HiDPI: single mode at requested resolution.
         var modes: [CGVirtualDisplayMode] = []
         if hiDPI {
             modes.append(CGVirtualDisplayMode(
@@ -75,12 +105,20 @@ class VirtualDisplayManager {
                 height: UInt32(physH),
                 refreshRate: Double(refreshRate)
             ))
+            for rung in Self.hiDPILogicalLadder(width: width, height: height) {
+                modes.append(CGVirtualDisplayMode(
+                    width: UInt32(rung.width),
+                    height: UInt32(rung.height),
+                    refreshRate: Double(refreshRate)
+                ))
+            }
+        } else {
+            modes.append(CGVirtualDisplayMode(
+                width: UInt32(width),
+                height: UInt32(height),
+                refreshRate: Double(refreshRate)
+            ))
         }
-        modes.append(CGVirtualDisplayMode(
-            width: UInt32(width),
-            height: UInt32(height),
-            refreshRate: Double(refreshRate)
-        ))
         settings.modes = modes
 
         self.displaySettings = settings

--- a/MacHost/Sources/VirtualDisplayManager.swift
+++ b/MacHost/Sources/VirtualDisplayManager.swift
@@ -9,6 +9,13 @@ class VirtualDisplayManager {
     private var displayDescriptor: CGVirtualDisplayDescriptor?
     private var displaySettings: CGVirtualDisplaySettings?
     private var screenParamsObserver: NSObjectProtocol?
+    /// Mode the display was last seen in, so the screen-params handler can tell a real
+    /// mode change from the many other topology events that fire the same notification.
+    private var lastSeenMode: (width: Int, height: Int, pixelWidth: Int, pixelHeight: Int)?
+
+    /// Fired when macOS switches the virtual display to a different mode, which the user
+    /// does from System Settings' scaling control. Carries the new logical size.
+    var onDisplayModeChanged: ((_ logicalWidth: Int, _ logicalHeight: Int) -> Void)?
 
     var displayID: CGDirectDisplayID? {
         return virtualDisplay?.displayID
@@ -140,7 +147,28 @@ class VirtualDisplayManager {
         let modeDesc = hiDPI ? "\(width)x\(height) HiDPI (physical \(physW)x\(physH))" : "\(width)x\(height)"
         print("✅ Virtual display created: \(modeDesc) @ \(refreshRate)Hz (ID: \(display.displayID))")
 
+        recordCurrentMode()
         registerScreenParamsObserver()
+    }
+
+    private func recordCurrentMode() {
+        guard let displayID = displayID, let mode = CGDisplayCopyDisplayMode(displayID) else { return }
+        lastSeenMode = (mode.width, mode.height, mode.pixelWidth, mode.pixelHeight)
+    }
+
+    /// The screen-params notification fires for every topology change, so compare against the
+    /// mode we last saw and stay silent unless this display actually switched.
+    private func reportModeChangeIfNeeded() {
+        guard let displayID = displayID, let mode = CGDisplayCopyDisplayMode(displayID) else { return }
+        let current = (mode.width, mode.height, mode.pixelWidth, mode.pixelHeight)
+        guard let previous = lastSeenMode else {
+            lastSeenMode = current
+            return
+        }
+        guard previous != current else { return }
+        lastSeenMode = current
+        print("🖥️  Virtual display mode changed: \(previous.width)x\(previous.height) -> \(current.0)x\(current.1) (physical \(current.2)x\(current.3))")
+        onDisplayModeChanged?(current.0, current.1)
     }
 
     /// Re-assert the physical-main invariant on every display-topology change:
@@ -157,6 +185,7 @@ class VirtualDisplayManager {
             queue: .main
         ) { [weak self] _ in
             self?.ensurePhysicalDisplayStaysMain()
+            self?.reportModeChangeIfNeeded()
         }
     }
 
@@ -165,6 +194,7 @@ class VirtualDisplayManager {
             NotificationCenter.default.removeObserver(token)
             screenParamsObserver = nil
         }
+        lastSeenMode = nil
     }
 
     /// Clone the main display configuration

--- a/MacHost/Tests/SideScreenTests/VirtualDisplayModeLadderTests.swift
+++ b/MacHost/Tests/SideScreenTests/VirtualDisplayModeLadderTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import SideScreen
+
+final class VirtualDisplayModeLadderTests: XCTestCase {
+    func testLadderStartsAtChosenSize() {
+        let ladder = VirtualDisplayManager.hiDPILogicalLadder(width: 2304, height: 1440)
+        XCTAssertEqual(ladder.first?.width, 2304)
+        XCTAssertEqual(ladder.first?.height, 1440)
+    }
+
+    func testLadderGivesMacOSEnoughRungsToDrawItsPicker() {
+        // A single logical mode leaves System Settings with no scaling control at all.
+        let ladder = VirtualDisplayManager.hiDPILogicalLadder(width: 2304, height: 1440)
+        XCTAssertGreaterThanOrEqual(ladder.count, 5)
+    }
+
+    func testEveryRungKeepsTheChosenAspectRatio() {
+        // A rung off the panel's aspect letterboxes on the client.
+        for (w, h) in [(2304, 1440), (1920, 1200), (2560, 1440), (1024, 768)] {
+            let aspect = Double(w) / Double(h)
+            for rung in VirtualDisplayManager.hiDPILogicalLadder(width: w, height: h) {
+                let rungAspect = Double(rung.width) / Double(rung.height)
+                XCTAssertEqual(rungAspect, aspect, accuracy: 0.01, "rung \(rung.width)x\(rung.height) for \(w)x\(h)")
+            }
+        }
+    }
+
+    func testRungsDescendAndAreUnique() {
+        let ladder = VirtualDisplayManager.hiDPILogicalLadder(width: 2304, height: 1440)
+        let widths = ladder.map(\.width)
+        XCTAssertEqual(widths, widths.sorted(by: >))
+        XCTAssertEqual(Set(widths).count, widths.count)
+    }
+
+    func testRungsAreEvenSoThePhysicalModeIsWhole() {
+        for rung in VirtualDisplayManager.hiDPILogicalLadder(width: 2304, height: 1440) {
+            XCTAssertEqual(rung.width % 2, 0)
+            XCTAssertEqual(rung.height % 2, 0)
+        }
+    }
+
+    func testKnownLadderForTabletPanel() {
+        let ladder = VirtualDisplayManager.hiDPILogicalLadder(width: 2304, height: 1440)
+        let rendered = ladder.map { "\($0.width)x\($0.height)" }
+        XCTAssertEqual(rendered, ["2304x1440", "2016x1260", "1728x1080", "1440x900", "1152x720"])
+    }
+
+    func testTinyResolutionCollapsesDuplicatesInsteadOfRepeating() {
+        let ladder = VirtualDisplayManager.hiDPILogicalLadder(width: 32, height: 20)
+        XCTAssertEqual(Set(ladder.map { "\($0.width)x\($0.height)" }).count, ladder.count)
+    }
+
+    func testZeroSizeYieldsNoRungs() {
+        XCTAssertTrue(VirtualDisplayManager.hiDPILogicalLadder(width: 0, height: 0).isEmpty)
+    }
+}


### PR DESCRIPTION
## Problem

Turn HiDPI on and the virtual display is genuinely Retina — `backingScaleFactor` is 2.0 and macOS renders a doubled framebuffer. But System Settings shows no "Larger Text … More Space" control for it, so scaling can only be changed from inside Side Screen, which tears the display down and restarts the stream.

macOS builds that control from a display's desktop-usable HiDPI modes. `VirtualDisplayManager.createDisplay` registers only two: the 2x anchor and the single logical size picked in the app. One rung is not a ladder, so the control never appears.

Counting modes where `pixelWidth > width` and `isUsableForDesktopGUI()` is true, on a 2304x1440 90Hz display:

```
2304x1440  <- px 4608x2880   usable
1152x720   <- px 2304x1440   NOT usable   <- exactly half the panel, the natural "Default" step
 960x600   <- px 1920x1200   usable       <- macOS generic fallback, not the panel's aspect
 800x600   <- px 1600x1200   usable       <- generic fallback, 4:3 on a 16:10 panel
```

Three usable rungs, only one of them actually on the panel's aspect ratio. For comparison, the built-in display on the same Mac reports 72.

## Fix

Register five logical rungs when HiDPI is on, at 1.0 / 0.875 / 0.75 / 0.625 / 0.5 of the chosen size. The chosen size stays the top rung, so the app still sets the ceiling and macOS scales down from there.

Rung heights are derived from the scaled width rather than scaled independently, so every rung holds the chosen aspect ratio. A rung that drifted off it would letterbox on the client. Sizes are rounded to even numbers because the physical mode is exactly twice the logical one, and duplicates are dropped so a small chosen resolution cannot register the same mode twice.

The non-HiDPI path is unchanged: still a single mode at the requested resolution.

## Verification

Measured on a real 2304x1440 90Hz virtual display, before and after:

```
before: 3 desktop-usable HiDPI rungs
after:  7 desktop-usable HiDPI rungs

  2304x1440 <- px 4608x2880
  2016x1260 <- px 4032x2520
  1728x1080 <- px 3456x2160
  1440x900  <- px 2880x1800
  1152x720  <- px 2304x1440
  960x600, 800x600 (macOS fallbacks, unchanged)
```

1152x720 is the clearest signal: it existed before but reported `isUsableForDesktopGUI()` false. Registering it explicitly flips it to true, which is what gives macOS a real "Default" step to anchor the picker on.

Builds clean; 43/43 tests pass, including 8 new ones covering rung ordering, aspect preservation across four panel shapes, even-sizing, duplicate collapsing, and the zero-size guard.

## Note

The ladder is most useful alongside a stream size bounded by what the client can decode. At 2304x1440 HiDPI the framebuffer is 4608x2880, which is past what a typical tablet decoder sustains, so without such a bound the higher rungs produce a black screen rather than a sharper picture. That bound is a separate change and not required for this one to be correct.

Refs #41
