### PR TITLE
fix: send the encoded stream size on the wire, desktop size separately

### DIFF
--- a/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
@@ -59,6 +59,12 @@ class MainActivity : AppCompatActivity() {
     private var currentSurfaceHolder: SurfaceHolder? = null
     private var currentTextureSurface: Surface? = null
     private var decoderUsingTextureView = false
+
+    // Logical desktop behind the stream, 0 when the Mac predates desktopGeometry.
+    // Shown next to the stream size; never used to size the decoder.
+    private var desktopWidth = 0
+    private var desktopHeight = 0
+
     private var displayWidth = 0 // 0 = no config received yet
     private var displayHeight = 0 // 0 = no config received yet
     private var displayRotation = 0 // 0, 90, 180, 270 degrees
@@ -920,6 +926,19 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    /**
+     * Stream size first, since that is what the decoder and every other stat in this overlay
+     * describe. The desktop size is appended only when it differs, so a scaled HiDPI desktop is
+     * visible rather than silently standing in for the resolution actually being sent.
+     */
+    private fun updateResolutionOverlay() {
+        if (displayWidth <= 0 || displayHeight <= 0) return
+        val stream = "${displayWidth}x$displayHeight"
+        val differs = desktopWidth > 0 && (desktopWidth != displayWidth || desktopHeight != displayHeight)
+        binding.resolutionText.text =
+            if (differs) "$stream (desktop ${desktopWidth}x$desktopHeight)" else stream
+    }
+
     private fun shouldUseTextureView(): Boolean = displayFlipHorizontal || displayFlipVertical
 
     private fun activeVideoSurface(): Pair<Surface, Boolean>? {
@@ -1094,6 +1113,12 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+        streamClient?.onDesktopSize = { w, h ->
+            desktopWidth = w
+            desktopHeight = h
+            runOnUiThread { updateResolutionOverlay() }
+        }
+
         streamClient?.onCodecSelected = { isHevc -> onStreamCodecSelected(isHevc) }
 
         streamClient?.onDisplaySize = { width, height, rotation, flipHorizontal, flipVertical ->
@@ -1105,7 +1130,7 @@ class MainActivity : AppCompatActivity() {
             displayFlipHorizontal = flipHorizontal
             displayFlipVertical = flipVertical
             runOnUiThread {
-                binding.resolutionText.text = "${width}x$height"
+                updateResolutionOverlay()
                 applyRotation(rotation, flipHorizontal, flipVertical)
                 initializeDecoderForCurrentSurface()
             }
@@ -1356,6 +1381,12 @@ class MainActivity : AppCompatActivity() {
 
                 streamClient?.onCodecSelected = { isHevc -> onStreamCodecSelected(isHevc) }
 
+                streamClient?.onDesktopSize = { w, h ->
+                    desktopWidth = w
+                    desktopHeight = h
+                    runOnUiThread { updateResolutionOverlay() }
+                }
+
                 streamClient?.onDisplaySize = { width, height, rotation, flipHorizontal, flipVertical ->
                     mainDiag("onDisplaySize: ${width}x$height @ $rotation°, h=$flipHorizontal, v=$flipVertical")
                     warnIfAvcOnlyWithoutNegotiation()
@@ -1366,7 +1397,7 @@ class MainActivity : AppCompatActivity() {
                     displayFlipVertical = flipVertical
 
                     runOnUiThread {
-                        binding.resolutionText.text = "${width}x$height"
+                        updateResolutionOverlay()
                         applyRotation(rotation, flipHorizontal, flipVertical)
                         initializeDecoderForCurrentSurface()
                     }
@@ -1415,6 +1446,8 @@ class MainActivity : AppCompatActivity() {
         // Reset display config so next connect defers decoder init until config arrives
         displayWidth = 0
         displayHeight = 0
+        desktopWidth = 0
+        desktopHeight = 0
         displayFlipHorizontal = false
         displayFlipVertical = false
         runOnUiThread {

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/StreamClient.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/StreamClient.kt
@@ -33,6 +33,9 @@ class StreamClient(
     var onFrameReceived: ((ByteArray, Int, Long, Boolean) -> Unit)? = null
     var onConnectionStatus: ((Boolean) -> Unit)? = null
     var onDisplaySize: ((Int, Int, Int, Boolean, Boolean) -> Unit)? = null
+
+    /** Logical desktop size behind the stream. Display only; never size the decoder from it. */
+    var onDesktopSize: ((Int, Int) -> Unit)? = null
     var onStats: ((Double, Double) -> Unit)? = null
 
     /** Invoked when the server confirms the stream codec (true = HEVC). */
@@ -128,6 +131,7 @@ class StreamClient(
                 codecNegotiated = false
                 advertiseAvcOnlyIfNeeded() // MUST precede type 8: type 8 can trigger the server's early protocol finish
                 advertiseDecoderLimits() // Also before type 8, for the same reason
+                advertiseDesktopGeometrySupport() // Likewise
                 advertiseFrameMetadataSupport()
                 isConnected = true
                 lastKeyframeReceivedNs = 0L
@@ -353,6 +357,7 @@ class StreamClient(
                 codecNegotiated = false
                 advertiseAvcOnlyIfNeeded() // MUST precede type 8: type 8 can trigger the server's early protocol finish
                 advertiseDecoderLimits() // Also before type 8, for the same reason
+                advertiseDesktopGeometrySupport() // Likewise
                 advertiseFrameMetadataSupport()
                 isConnected = true
                 diagLog("Wireless connected to $host:$port")
@@ -373,6 +378,14 @@ class StreamClient(
                 }
                 throw WirelessConnectError.ProtocolError
             }
+        }
+    }
+
+    private fun advertiseDesktopGeometrySupport() {
+        outputStream?.let { out ->
+            out.writeByte(MESSAGE_CLIENT_SUPPORTS_DESKTOP_GEOMETRY)
+            out.flush()
+            diagLog("Advertised desktop-geometry support")
         }
     }
 
@@ -447,6 +460,13 @@ class StreamClient(
                             val sentTime = ByteBuffer.wrap(buf).order(ByteOrder.LITTLE_ENDIAN).long
                             val rtt = (System.nanoTime() - sentTime) / 1_000_000.0 // ms
                             onLatencyMeasured?.invoke(rtt)
+                        }
+
+                        MESSAGE_DESKTOP_GEOMETRY -> {
+                            val dw = input.readInt()
+                            val dh = input.readInt()
+                            diagLog("Desktop geometry: ${dw}x$dh")
+                            onDesktopSize?.invoke(dw, dh)
                         }
 
                         MESSAGE_CODEC_SELECTED -> {
@@ -704,6 +724,8 @@ class StreamClient(
         private const val MESSAGE_CLIENT_AVC_ONLY = 9
         private const val MESSAGE_CODEC_SELECTED = 10
         private const val MESSAGE_CLIENT_DECODER_LIMITS = 11
+        private const val MESSAGE_CLIENT_SUPPORTS_DESKTOP_GEOMETRY = 12
+        private const val MESSAGE_DESKTOP_GEOMETRY = 13
         private const val FRAME_FLAG_KEYFRAME = 1
         private const val KEYFRAME_REQUEST_FLAG_FORCE = 1
 

--- a/MacHost/Sources/AppDelegate.swift
+++ b/MacHost/Sources/AppDelegate.swift
@@ -628,13 +628,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     }
                 }
             }
-            // Send the LOGICAL resolution that the user picked. The H.264 SPS in
-            // the stream still carries the true physical pixel dimensions, so the
-            // Android decoder/MediaCodec sets up correctly regardless. Sending the
-            // logical dimensions here makes the resolution overlay on Android
-            // match the Mac's resolution dropdown (e.g. "2560x1600" instead of
-            // the HiDPI-doubled "5120x3200").
-            streamingServer?.setDisplaySize(width: size.width, height: size.height, rotation: settings.rotation, flipHorizontal: settings.flipHorizontal, flipVertical: settings.flipVertical)
+            // displayConfig carries the ENCODED size, always. The client sizes and
+            // selects its decoder from it, so a friendlier number here makes it
+            // check capabilities against a resolution it will never receive. The
+            // logical desktop travels separately, for display only.
+            let initialEncode = ScreenCapture.physicalSize(for: displayID)
+            streamingServer?.setDesktopSize(width: size.width, height: size.height)
+            streamingServer?.setDisplaySize(width: initialEncode.width, height: initialEncode.height, rotation: settings.rotation, flipHorizontal: settings.flipHorizontal, flipVertical: settings.flipVertical)
             streamingServer?.onClientConnected = { [weak self] in
                 guard let self = self else { return }
                 self.screenCapture?.requestKeyframeOrReplayCachedFrame(force: true)
@@ -649,13 +649,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 guard let self = self, let capture = self.screenCapture else { return }
                 capture.negotiate(codec: codec, clientLimit: self.streamingServer?.clientDecodeLimits)
                 let enc = capture.encodeSize(for: codec)
-                // Unclamped HEVC keeps the logical user-picked resolution,
-                // exactly as at startup; any clamped size (client decoder
-                // limit, or the AVC floor) must match what the stream's SPS
-                // will carry so the client sizes its decoder correctly.
-                let unclampedHevc = codec == .hevc && enc == (capture.displayWidth, capture.displayHeight)
-                let (w, h) = unclampedHevc ? (size.width, size.height) : (enc.width, enc.height)
-                self.streamingServer?.setDisplaySize(width: w, height: h, rotation: self.settings.rotation, flipHorizontal: self.settings.flipHorizontal, flipVertical: self.settings.flipVertical)
+                // Whatever the codec negotiation settled on, this is what the
+                // stream's SPS will carry, so it is what the client must size
+                // its decoder for.
+                self.streamingServer?.setDesktopSize(width: size.width, height: size.height)
+                self.streamingServer?.setDisplaySize(width: enc.width, height: enc.height, rotation: self.settings.rotation, flipHorizontal: self.settings.flipHorizontal, flipVertical: self.settings.flipVertical)
             }
             streamingServer?.onKeyframeRequested = { [weak self] force in
                 self?.screenCapture?.requestKeyframeOrReplayCachedFrame(force: force)

--- a/MacHost/Sources/StreamingServer.swift
+++ b/MacHost/Sources/StreamingServer.swift
@@ -22,6 +22,13 @@ private enum WireMessage {
     /// #41). Every payload byte has the high bit set, so old hosts that
     /// consume unknown types byte-by-byte skip the payload harmlessly.
     static let clientDecoderLimits: UInt8 = 11
+    /// Client→server, payload-free: "I understand desktopGeometry, and I read
+    /// displayConfig as the encoded stream size."
+    static let clientSupportsDesktopGeometry: UInt8 = 12
+    /// Server→client, 8-byte payload: the logical desktop size, for display
+    /// only. Sent ONLY to clients that sent clientSupportsDesktopGeometry —
+    /// older clients disconnect on unknown message types.
+    static let desktopGeometry: UInt8 = 13
 }
 
 private extension NWEndpoint {
@@ -122,6 +129,11 @@ class StreamingServer {
     private var clientIsAvcOnly = false
     /// Max decode size reported by the connected client (issue #41).
     private(set) var clientDecodeLimits: (width: Int, height: Int)?
+    /// Set when the client opts in via type 12. Gates desktopGeometry sends.
+    private var clientSupportsDesktopGeometry = false
+    /// Logical desktop size, reported alongside the encoded size for display.
+    private var desktopWidth = 0
+    private var desktopHeight = 0
     private var inputBuffer = Data()
 
     init(port: UInt16) {
@@ -175,6 +187,7 @@ class StreamingServer {
         clientSupportsFrameMetadata = false
         clientIsAvcOnly = false
         clientDecodeLimits = nil
+        clientSupportsDesktopGeometry = false
         waitingForSyncFrame = true
         inputBuffer.removeAll(keepingCapacity: true)
         connection = newConnection
@@ -407,6 +420,13 @@ class StreamingServer {
         })
     }
 
+    /// The logical desktop the user picked. Purely informational: the client
+    /// must size its decoder from displayConfig, never from this.
+    func setDesktopSize(width: Int, height: Int) {
+        desktopWidth = width
+        desktopHeight = height
+    }
+
     func setDisplaySize(width: Int, height: Int, rotation: Int = 0, flipHorizontal: Bool = false, flipVertical: Bool = false) {
         displayWidth = width
         displayHeight = height
@@ -434,6 +454,20 @@ class StreamingServer {
 
         connection.send(content: data, completion: .contentProcessed { _ in })
         debugLog("Sent display config: \(displayWidth)x\(displayHeight) @ \(rotation)°, h=\(flipHorizontal), v=\(flipVertical)")
+        sendDesktopGeometry()
+    }
+
+    /// Follows every display config so the two can never disagree on screen.
+    private func sendDesktopGeometry() {
+        guard clientSupportsDesktopGeometry, let connection = connection else { return }
+        guard desktopWidth > 0, desktopHeight > 0 else { return }
+
+        var data = Data()
+        data.append(WireMessage.desktopGeometry)
+        data.append(contentsOf: withUnsafeBytes(of: Int32(desktopWidth).bigEndian) { Data($0) })
+        data.append(contentsOf: withUnsafeBytes(of: Int32(desktopHeight).bigEndian) { Data($0) })
+        connection.send(content: data, completion: .contentProcessed { _ in })
+        debugLog("Sent desktop geometry: \(desktopWidth)x\(desktopHeight)")
     }
 
     private func startReceivingTouch() {
@@ -562,6 +596,15 @@ class StreamingServer {
                 if w >= 256 && h >= 256 {
                     clientDecodeLimits = (w, h)
                     debugLog("Client decoder limit: \(w)x\(h)")
+                }
+
+            case WireMessage.clientSupportsDesktopGeometry:
+                // Payload-free opt-in (same convention as types 8 and 9), sent
+                // BEFORE type 8 so it lands before finishProtocolStartup runs.
+                consumeInputBytes(1)
+                if !clientSupportsDesktopGeometry {
+                    clientSupportsDesktopGeometry = true
+                    debugLog("Client reads displayConfig as the encoded size")
                 }
 
             default:


### PR DESCRIPTION
## Problem

`displayConfig` is not only what the client's overlay renders. It is what the client sizes and selects its decoder from:

```kotlin
// VideoDecoder.kt, decoder selection
val supported     = videoCaps.isSizeSupported(width, height)
val rateSupported = videoCaps.areSizeAndRateSupported(width, height, targetRate)

// VideoDecoder.kt, configuration
MediaFormat.createVideoFormat(mime, currentWidth, currentHeight)
```

With HiDPI on, `AppDelegate` sends the logical resolution so the overlay matches the Mac's resolution dropdown, while the stream is the doubled frame. Observed on 0.11.2 with HiDPI at 2560x1600:

```
Sent display config:  2560x1600      <- client sized its decoder from this
Stream configured:    5120x3200      <- client was actually fed this
```

The client asks "can you decode 2560x1600 at 90fps", is told yes, picks a decoder on that basis, and is handed 5120x3200. The only throughput check that exists on the client runs against a resolution that is never the stream. MediaCodec does adapt from the SPS afterwards, but decoder selection and the capability check have already happened by then.

The intent behind sending the logical size is good and worth keeping: an overlay reading "5120x3200" when the user picked 2560x1600 is confusing. The mistake is carrying it in the field the decoder reads.

## Fix

`displayConfig` always carries the encoded size now. The logical desktop moves to its own message.

| Type | Direction | Payload | Meaning |
|---|---|---|---|
| 12 | client to server | none | "I read displayConfig as the encoded size and understand type 13" |
| 13 | server to client | 8 bytes | logical desktop size, display only |

Type 13 goes only to clients that sent type 12, because older clients disconnect on unknown message types (the same constraint that governs `codecSelected`). Older hosts consume type 12 as a single unknown byte and carry on. Both directions stay compatible.

The overlay shows the stream size, appending the desktop size only when the two differ:

```
2304x1440 (desktop 2560x1600)
```

so a scaled HiDPI desktop is visible rather than quietly standing in for the resolution being sent.

## Verification

On device, HiDPI at 1920x1080:

```
Mac    -> Sent display config:   3840x2160
Mac    -> Sent desktop geometry: 1920x1080
Tablet -> Display config:   3840x2160
Tablet -> Desktop geometry: 1920x1080
Tablet -> setupDecoder: 3840x2160, decoder=c2.exynos.hevc.decoder
```

The decoder is configured for the frame it will actually receive. Before this change it was configured for 1920x1080 and fed 3840x2160.

Handshake ordering is unchanged: type 12 is advertised alongside types 9 and 11, before type 8, so it lands before `finishProtocolStartup` runs and the first `displayConfig` goes out.

macOS builds clean, 35/35 tests pass. Android compiles clean, unit tests pass, ktlint clean.

## Note on scope

This removes the `unclampedHevc` branch in `AppDelegate`, which existed to keep the logical resolution for unclamped HEVC. With the encoded size always on the wire, that special case has nothing left to do.

Independent of the decode-ceiling work in #62: no shared files, and either can land first. #62 makes the clamp engage more often, which happens to route around this bug in those cases. This PR fixes it outright, including the case #62 does not reach, where the client genuinely can decode the doubled frame and no clamping occurs.
