### PR TITLE
fix(android): bypass vendor limited-range YUV conversion

### DIFF
--- a/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
@@ -942,7 +942,6 @@ class MainActivity : AppCompatActivity() {
                             CodecCapabilities.REFERENCE_FPS,
                         )
                     }
-                val cap = CodecCapabilities.maxDecodeSize(mime)
 
                 runOnUiThread {
                     val capText =

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
@@ -10,6 +10,7 @@ import android.graphics.Color
 import android.graphics.Matrix
 import android.graphics.SurfaceTexture
 import android.graphics.drawable.ColorDrawable
+import android.hardware.DataSpace
 import android.hardware.usb.UsbManager
 import android.media.MediaFormat
 import android.os.Build
@@ -21,6 +22,7 @@ import android.provider.Settings
 import android.view.MotionEvent
 import android.view.Surface
 import android.view.SurfaceHolder
+import android.view.SurfaceControl
 import android.view.TextureView
 import android.view.View
 import android.view.Window
@@ -309,6 +311,26 @@ class MainActivity : AppCompatActivity() {
                     mainDiag("surfaceChanged: ${width}x$height")
                     log("Surface changed: ${width}x$height")
                     currentSurfaceHolder = holder
+
+                    // Explicitly identify the video surface as BT.709.
+                    // applyTransactionToFrame() applies the dataspace to the
+                    // frame being presented by SurfaceView.
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                        try {
+                            val transaction = SurfaceControl.Transaction()
+                                .setDataSpace(
+                                    binding.surfaceView.surfaceControl,
+                                    DataSpace.DATASPACE_BT709,
+                                )
+
+                            binding.surfaceView.applyTransactionToFrame(transaction)
+
+                            mainDiag("SurfaceView dataspace set to BT709")
+                        } catch (e: Exception) {
+                            mainDiag("Failed to set SurfaceView dataspace: ${e.message}")
+                        }
+                    }
+
                     initializeDecoderForCurrentSurface()
                 }
 

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/MainActivity.kt
@@ -7,10 +7,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.ActivityInfo
 import android.graphics.Color
-import android.graphics.Matrix
-import android.graphics.SurfaceTexture
 import android.graphics.drawable.ColorDrawable
-import android.hardware.DataSpace
 import android.hardware.usb.UsbManager
 import android.media.MediaFormat
 import android.os.Build
@@ -20,10 +17,6 @@ import android.os.Looper
 import android.os.PowerManager
 import android.provider.Settings
 import android.view.MotionEvent
-import android.view.Surface
-import android.view.SurfaceHolder
-import android.view.SurfaceControl
-import android.view.TextureView
 import android.view.View
 import android.view.Window
 import android.view.WindowInsets
@@ -54,13 +47,11 @@ class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
     private lateinit var prefs: PreferencesManager
     private var videoDecoder: VideoDecoder? = null
+    private val videoFramePool = VideoFramePool()
     private var streamClient: StreamClient? = null
 
     /** In-flight code-pairing attempt (issue #35); cancelled when its dialog closes. */
     private var pairingJob: Job? = null
-    private var currentSurfaceHolder: SurfaceHolder? = null
-    private var currentTextureSurface: Surface? = null
-    private var decoderUsingTextureView = false
     private var displayWidth = 0 // 0 = no config received yet
     private var displayHeight = 0 // 0 = no config received yet
     private var displayRotation = 0 // 0, 90, 180, 270 degrees
@@ -109,7 +100,7 @@ class MainActivity : AppCompatActivity() {
         // Enable performance mode for gaming (after binding is initialized)
         enablePerformanceMode()
 
-        setupSurface()
+        setupVideoView()
         setupUI()
         setupDraggableOverlay()
         setupSettingsButton()
@@ -294,102 +285,10 @@ class MainActivity : AppCompatActivity() {
     }
 
     @SuppressLint("ClickableViewAccessibility")
-    private fun setupSurface() {
-        binding.surfaceView.holder.addCallback(
-            object : SurfaceHolder.Callback {
-                override fun surfaceCreated(holder: SurfaceHolder) {
-                    mainDiag("surfaceCreated")
-                    log("Surface created")
-                }
+    private fun setupVideoView() {
+        binding.videoView.framePool = videoFramePool
 
-                override fun surfaceChanged(
-                    holder: SurfaceHolder,
-                    format: Int,
-                    width: Int,
-                    height: Int,
-                ) {
-                    mainDiag("surfaceChanged: ${width}x$height")
-                    log("Surface changed: ${width}x$height")
-                    currentSurfaceHolder = holder
-
-                    // Explicitly identify the video surface as BT.709.
-                    // applyTransactionToFrame() applies the dataspace to the
-                    // frame being presented by SurfaceView.
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                        try {
-                            val transaction = SurfaceControl.Transaction()
-                                .setDataSpace(
-                                    binding.surfaceView.surfaceControl,
-                                    DataSpace.DATASPACE_BT709,
-                                )
-
-                            binding.surfaceView.applyTransactionToFrame(transaction)
-
-                            mainDiag("SurfaceView dataspace set to BT709")
-                        } catch (e: Exception) {
-                            mainDiag("Failed to set SurfaceView dataspace: ${e.message}")
-                        }
-                    }
-
-                    initializeDecoderForCurrentSurface()
-                }
-
-                override fun surfaceDestroyed(holder: SurfaceHolder) {
-                    mainDiag("surfaceDestroyed")
-                    log("Surface destroyed")
-                    if (!decoderUsingTextureView) {
-                        videoDecoder?.release()
-                        videoDecoder = null
-                    }
-                    currentSurfaceHolder = null
-                }
-            },
-        )
-
-        binding.textureView.surfaceTextureListener =
-            object : TextureView.SurfaceTextureListener {
-                override fun onSurfaceTextureAvailable(
-                    surface: SurfaceTexture,
-                    width: Int,
-                    height: Int,
-                ) {
-                    mainDiag("textureAvailable: ${width}x$height")
-                    currentTextureSurface = Surface(surface)
-                    initializeDecoderForCurrentSurface()
-                }
-
-                override fun onSurfaceTextureSizeChanged(
-                    surface: SurfaceTexture,
-                    width: Int,
-                    height: Int,
-                ) {
-                    mainDiag("textureSizeChanged: ${width}x$height")
-                    applyTextureTransform()
-                }
-
-                override fun onSurfaceTextureDestroyed(surface: SurfaceTexture): Boolean {
-                    mainDiag("textureDestroyed")
-                    if (decoderUsingTextureView) {
-                        videoDecoder?.release()
-                        videoDecoder = null
-                    }
-                    currentTextureSurface?.release()
-                    currentTextureSurface = null
-                    return true
-                }
-
-                override fun onSurfaceTextureUpdated(surface: SurfaceTexture) = Unit
-            }
-
-        if (binding.textureView.isAvailable && currentTextureSurface == null) {
-            binding.textureView.surfaceTexture?.let { currentTextureSurface = Surface(it) }
-        }
-
-        binding.surfaceView.setOnTouchListener { view, event ->
-            handleTouch(view, event)
-            true
-        }
-        binding.textureView.setOnTouchListener { view, event ->
+        binding.videoView.setOnTouchListener { view, event ->
             handleTouch(view, event)
             true
         }
@@ -930,61 +829,45 @@ class MainActivity : AppCompatActivity() {
             when {
                 dec == null -> {
                     mainDiag("Codec selected ($expectedMime) — initializing deferred decoder")
-                    initializeDecoderForCurrentSurface()
+                    initializeDecoder()
                 }
                 dec.mime != expectedMime -> {
                     mainDiag("Stream codec is $expectedMime but decoder is ${dec.mime} — recreating")
                     dec.release()
                     videoDecoder = null
-                    initializeDecoderForCurrentSurface()
+                    initializeDecoder()
                 }
             }
         }
     }
 
-    private fun shouldUseTextureView(): Boolean = displayFlipHorizontal || displayFlipVertical
-
-    private fun activeVideoSurface(): Pair<Surface, Boolean>? {
-        return if (shouldUseTextureView()) {
-            currentTextureSurface?.takeIf { it.isValid }?.let { it to true }
-        } else {
-            currentSurfaceHolder?.surface?.takeIf { it.isValid }?.let { it to false }
-        }
-    }
-
-    private fun initializeDecoderForCurrentSurface() {
+    private fun initializeDecoder() {
         if (displayWidth <= 0 || displayHeight <= 0) {
             mainDiag("initializeDecoder skipped — no display config yet")
             return
         }
-        // AVC-only device: an HEVC decoder can never decode the H.264 stream
-        // the Mac will send — defer until codecSelected arrives, then
-        // onStreamCodecSelected initializes with the correct mime.
-        if (!CodecCapabilities.hasHevcDecoder && streamClient?.codecNegotiated != true) {
-            mainDiag("initializeDecoder deferred — AVC-only device awaiting codec negotiation")
+
+        // AVC-only device: wait for codec negotiation before creating the decoder.
+        if (!CodecCapabilities.hasHevcDecoder &&
+            streamClient?.codecNegotiated != true
+        ) {
+            mainDiag(
+                "initializeDecoder deferred — AVC-only device awaiting codec negotiation"
+            )
             return
         }
 
-        val (surface, useTextureView) =
-            activeVideoSurface() ?: run {
-                val kind = if (shouldUseTextureView()) "TextureView" else "SurfaceView"
-                mainDiag("initializeDecoder skipped — no valid $kind surface")
-                return
-            }
+        val existing = videoDecoder
 
-        if (videoDecoder != null && decoderUsingTextureView == useTextureView) {
-            videoDecoder?.updateResolution(displayWidth, displayHeight)
+        if (existing != null) {
+            existing.updateResolution(displayWidth, displayHeight)
             return
         }
-
-        videoDecoder?.release()
-        videoDecoder = null
-        decoderUsingTextureView = useTextureView
 
         mainDiag(
-            "initializeDecoder called, surface=$surface, valid=${surface.isValid}, " +
-                "res=${displayWidth}x$displayHeight, texture=$useTextureView",
+            "initializeDecoder called, res=${displayWidth}x$displayHeight"
         )
+
         try {
             val displayObj =
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -993,45 +876,87 @@ class MainActivity : AppCompatActivity() {
                     @Suppress("DEPRECATION")
                     windowManager.defaultDisplay
                 }
+
             val mime =
                 if (streamClient?.streamCodecIsHevc == false) {
                     MediaFormat.MIMETYPE_VIDEO_AVC
                 } else {
                     MediaFormat.MIMETYPE_VIDEO_HEVC
                 }
-            videoDecoder = VideoDecoder(surface, displayObj, displayWidth, displayHeight, mime)
+
+            videoDecoder = VideoDecoder(
+                videoFramePool,
+                displayObj,
+                displayWidth,
+                displayHeight,
+                mime
+            )
+
+            videoDecoder?.onFrame = { frame ->
+                binding.videoView.pushFrame(frame)
+            }
+
             videoDecoder?.onFrameDecoded = { buffer ->
                 streamClient?.releaseBuffer(buffer)
             }
+
             videoDecoder?.onKeyframeRequired = { force, reason ->
-                streamClient?.requestKeyframe(force = force, reason = reason)
+                streamClient?.requestKeyframe(
+                    force = force,
+                    reason = reason
+                )
             }
+
             videoDecoder?.onDecoderStalled = {
-                // Black screen with live stats: tell the user why instead of
-                // staying silent (issue #41). Toast renders above the (black)
-                // SurfaceView; the settings panel is hidden while streaming.
                 val cap = CodecCapabilities.maxDecodeSize(mime)
+
                 runOnUiThread {
-                    val capText = cap?.let { " (max ~${it.first}×${it.second})" } ?: ""
+                    val capText =
+                        cap?.let {
+                            " (max ~${it.first}×${it.second})"
+                        } ?: ""
+
                     android.widget.Toast
                         .makeText(
                             this,
                             "No video output — the stream resolution may exceed " +
                                 "this tablet's decoder limit$capText. " +
                                 "Lower the resolution or disable HiDPI on the Mac.",
-                            android.widget.Toast.LENGTH_LONG,
-                        ).show()
+                            android.widget.Toast.LENGTH_LONG
+                        )
+                        .show()
                 }
             }
-            streamClient?.requestKeyframe(force = true, reason = "decoder initialized")
-            mainDiag("Decoder initialized OK ${displayWidth}x$displayHeight mime=$mime, texture=$useTextureView")
-            log("✅ Decoder initialized ${displayWidth}x$displayHeight $mime (${displayObj?.refreshRate ?: 60f}Hz)")
+
+            streamClient?.requestKeyframe(
+                force = true,
+                reason = "decoder initialized"
+            )
+
+            mainDiag(
+                "Decoder initialized OK " +
+                    "${displayWidth}x$displayHeight mime=$mime"
+            )
+
+            log(
+                "✅ Decoder initialized " +
+                    "${displayWidth}x$displayHeight " +
+                    "$mime (${displayObj?.refreshRate ?: 60f}Hz)"
+            )
+
         } catch (e: Exception) {
-            decoderUsingTextureView = false
-            mainDiag("Decoder init FAILED: ${e.message}")
-            log("❌ Failed to initialize decoder: ${e.message}")
+            mainDiag(
+                "Decoder init FAILED: ${e.message}"
+            )
+
+            log(
+                "❌ Failed to initialize decoder: ${e.message}"
+            )
+
             runOnUiThread {
-                updateStatus("Video decoder failed: ${e.message}")
+                updateStatus(
+                    "Video decoder failed: ${e.message}"
+                )
             }
         }
     }
@@ -1129,7 +1054,7 @@ class MainActivity : AppCompatActivity() {
             runOnUiThread {
                 binding.resolutionText.text = "${width}x$height"
                 applyRotation(rotation, flipHorizontal, flipVertical)
-                initializeDecoderForCurrentSurface()
+                initializeDecoder()
             }
             log("Display: ${width}x$height @ $rotation°")
         }
@@ -1390,7 +1315,7 @@ class MainActivity : AppCompatActivity() {
                     runOnUiThread {
                         binding.resolutionText.text = "${width}x$height"
                         applyRotation(rotation, flipHorizontal, flipVertical)
-                        initializeDecoderForCurrentSurface()
+                        initializeDecoder()
                     }
                     log("Display: ${width}x$height @ $rotation°")
                 }
@@ -1440,8 +1365,7 @@ class MainActivity : AppCompatActivity() {
         displayFlipHorizontal = false
         displayFlipVertical = false
         runOnUiThread {
-            binding.textureView.visibility = View.GONE
-            applyTextureTransform()
+            binding.videoView.clearFrames()
         }
         log("Disconnected")
     }
@@ -1467,8 +1391,6 @@ class MainActivity : AppCompatActivity() {
             disconnect()
             videoDecoder?.release()
             videoDecoder = null
-            currentTextureSurface?.release()
-            currentTextureSurface = null
 
             // Release wake lock safely
             try {
@@ -1554,10 +1476,10 @@ class MainActivity : AppCompatActivity() {
                 else -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
             }
 
-        binding.surfaceView.rotation = 0f
-        binding.surfaceView.visibility = View.VISIBLE
-        binding.textureView.visibility = if (flipHorizontal || flipVertical) View.VISIBLE else View.GONE
-        applyTextureTransform()
+        binding.videoView.setFlip(
+            flipHorizontal,
+            flipVertical
+        )
 
         log(
             "🔄 Orientation: ${when (rotation) {
@@ -1565,22 +1487,8 @@ class MainActivity : AppCompatActivity() {
                 180 -> "Landscape (flipped)"
                 270 -> "Portrait (flipped)"
                 else -> "Landscape"
-            }}${if (flipHorizontal || flipVertical) " mirrored" else ""}",
+            }}${if (flipHorizontal || flipVertical) " mirrored" else ""}"
         )
-    }
-
-    private fun applyTextureTransform() {
-        val view = binding.textureView
-        val matrix = Matrix()
-        val centerX = view.width / 2f
-        val centerY = view.height / 2f
-        matrix.postScale(
-            if (displayFlipHorizontal) -1f else 1f,
-            if (displayFlipVertical) -1f else 1f,
-            centerX,
-            centerY,
-        )
-        view.setTransform(matrix)
     }
 
     /**

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/VideoDecoder.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/VideoDecoder.kt
@@ -3,18 +3,19 @@ package com.sidescreen.app
 import android.media.MediaCodec
 import android.media.MediaCodecList
 import android.media.MediaFormat
+import android.media.Image
+import java.nio.ByteBuffer
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Process
 import android.util.Log
 import android.view.Display
-import android.view.Surface
 import java.util.concurrent.ConcurrentLinkedQueue
 
 private fun diagLog(msg: String) = DiagLog.log("VD", msg)
 
 class VideoDecoder(
-    private val surface: Surface,
+    private val framePool: VideoFramePool,
     private val display: Display? = null,
     initialWidth: Int = 1920,
     initialHeight: Int = 1200,
@@ -56,6 +57,16 @@ class VideoDecoder(
 
     var onFrameRendered: ((Long) -> Unit)? = null
     var onFrameStats: ((fps: Double, variance: Double) -> Unit)? = null
+    var onFrame: ((VideoFrame) -> Unit)? = null
+
+    private var pixelFormat = VideoPixelFormat.YUV420P
+    private var chromaInterleaved = false
+    private var outStride = 0
+    private var outSliceHeight = 0
+    private var outWidth = initialWidth
+    private var outHeight = initialHeight
+    private var discardOutputsUntilKeyframe = false
+    private var planeScratch = ByteArray(0)
     var onFrameDecoded: ((ByteArray) -> Unit)? = null
     var onKeyframeRequired: ((force: Boolean, reason: String) -> Unit)? = null
 
@@ -153,7 +164,7 @@ class VideoDecoder(
             format.setInteger(MediaFormat.KEY_PRIORITY, 0)
             format.setInteger(MediaFormat.KEY_OPERATING_RATE, displayRefreshRate.toInt())
             format.setInteger(MediaFormat.KEY_MAX_B_FRAMES, 0)
-            codec.configure(format, surface, null, 0)
+            codec.configure(format, null, null, 0)
             configured = true
             diagLog("Configured with full low-latency")
         } catch (e: Exception) {
@@ -173,7 +184,7 @@ class VideoDecoder(
                     )
                 basicFormat.setInteger(MediaFormat.KEY_PRIORITY, 0)
                 basicFormat.setInteger(MediaFormat.KEY_MAX_B_FRAMES, 0)
-                codec.configure(basicFormat, surface, null, 0)
+                codec.configure(basicFormat, null, null, 0)
                 configured = true
                 diagLog("Configured with basic format")
             } catch (e: Exception) {
@@ -192,7 +203,7 @@ class VideoDecoder(
                         currentWidth,
                         currentHeight,
                     )
-                codec.configure(minimalFormat, surface, null, 0)
+                codec.configure(minimalFormat, null, null, 0)
                 diagLog("Configured with minimal format")
             } catch (e: Exception) {
                 diagLog("All configure attempts failed: ${e.message}")
@@ -212,7 +223,7 @@ class VideoDecoder(
         decoder = codec
         diagLog(
             "Decoder started: ${currentWidth}x$currentHeight @ ${displayRefreshRate}Hz, " +
-                "surface=$surface, valid=${surface.isValid}",
+                "output=byte-buffer",
         )
     }
 
@@ -314,7 +325,7 @@ class VideoDecoder(
                     .joinToString(" ") { String.format("%02x", it) }
             diagLog(
                 "First frame: size=$frameSize, header=[$header], " +
-                    "keyframe=$isKeyframe, surface=$surface, valid=${surface.isValid}",
+                    "keyframe=$isKeyframe, output=byte-buffer",
             )
         }
         if (inputFrameCount % 60L == 0L) {
@@ -437,16 +448,15 @@ class VideoDecoder(
     ) {
         try {
             outputFrameCount++
+
             if (outputFrameCount == 1L) {
                 diagLog("First output frame! size=${info.size}, flags=${info.flags}")
             }
 
-            // Decoder latency: time from queueInputBuffer (where we encoded
-            // System.nanoTime()/1000 as PTS) to now. Captures how long the
-            // frame spent inside the codec's input/reorder/output queues.
             val nowNs = System.nanoTime()
             val latencyNs = nowNs - info.presentationTimeUs * 1000L
             val hasValidLatency = latencyNs in 0..MAX_REASONABLE_LATENCY_NS
+
             if (hasValidLatency) {
                 latencySumNs += latencyNs
                 latencySamples++
@@ -454,14 +464,23 @@ class VideoDecoder(
             }
 
             if (outputFrameCount % 60L == 0L) {
-                val avgMs = if (latencySamples > 0) latencySumNs / latencySamples / 1_000_000.0 else 0.0
+                val avgMs =
+                    if (latencySamples > 0) {
+                        latencySumNs / latencySamples / 1_000_000.0
+                    } else {
+                        0.0
+                    }
                 val maxMs = latencyMaxNs / 1_000_000.0
-                val inBufs = availableInputBuffers.size
+
                 diagLog(
-                    "Output #$outputFrameCount: decoder latency avg=${"%.1f".format(avgMs)}ms " +
-                        "max=${"%.1f".format(maxMs)}ms over $latencySamples samples, " +
-                        "input bufs avail=$inBufs, dropped=$droppedFrames",
+                    "Output #$outputFrameCount: decoder latency " +
+                        "avg=${"%.1f".format(avgMs)}ms " +
+                        "max=${"%.1f".format(maxMs)}ms " +
+                        "over $latencySamples samples, " +
+                        "input bufs avail=${availableInputBuffers.size}, " +
+                        "dropped=$droppedFrames",
                 )
+
                 latencySumNs = 0
                 latencySamples = 0
                 latencyMaxNs = 0
@@ -475,26 +494,454 @@ class VideoDecoder(
             if (!shouldRender) {
                 droppedFrames++
                 staleOutputDrops++
+
                 if (staleOutputDrops <= 3L || staleOutputDrops % 60L == 0L) {
                     diagLog(
-                        "Dropping stale output frame: latency=${"%.1f".format(latencyNs / 1_000_000.0)}ms, " +
+                        "Dropping stale output frame: " +
+                            "latency=${"%.1f".format(latencyNs / 1_000_000.0)}ms, " +
                             "staleDrops=$staleOutputDrops",
                     )
                 }
+
                 codec.releaseOutputBuffer(index, false)
                 updateStats()
                 return
             }
 
-            codec.releaseOutputBuffer(index, true)
-            trackFrameTiming(System.nanoTime())
-            updateStats()
+            if (discardOutputsUntilKeyframe) {
+                if ((info.flags and MediaCodec.BUFFER_FLAG_KEY_FRAME) == 0) {
+                    codec.releaseOutputBuffer(index, false)
+                    droppedFrames++
+                    updateStats()
+                    return
+                }
+
+                discardOutputsUntilKeyframe = false
+                diagLog("Resumed output at keyframe")
+            }
+
+            detectOutputFormat(codec)
+
+            val width = outWidth.coerceAtLeast(1)
+            val height = outHeight.coerceAtLeast(1)
+
+            val frame = framePool.acquire(pixelFormat, width, height)
+
+            try {
+                if (!fillFrame(codec, index, pixelFormat, width, height, frame)) {
+                    framePool.release(frame)
+                    codec.releaseOutputBuffer(index, false)
+                    droppedFrames++
+                    return
+                }
+
+                onFrame?.invoke(frame)
+                trackFrameTiming(nowNs)
+                updateStats()
+
+                // Ownership transfers to the renderer callback.
+                // It must return the frame to framePool when no longer needed.
+            } catch (e: Exception) {
+                framePool.release(frame)
+                throw e
+            } finally {
+                codec.releaseOutputBuffer(index, false)
+            }
         } catch (e: Exception) {
-            Log.e(TAG, "releaseOutputBuffer failed", e)
+            Log.e(TAG, "Output buffer handling failed", e)
             try {
                 codec.releaseOutputBuffer(index, false)
             } catch (_: Exception) {
             }
+        }
+    }
+
+    private fun detectOutputFormat(codec: MediaCodec) {
+        val format = try {
+            codec.outputFormat
+        } catch (_: Exception) {
+            return
+        }
+
+        val colorFormat =
+            if (format.containsKey(MediaFormat.KEY_COLOR_FORMAT)) {
+                format.getInteger(MediaFormat.KEY_COLOR_FORMAT)
+            } else {
+                0
+            }
+
+        outWidth =
+            if (format.containsKey(MediaFormat.KEY_WIDTH)) {
+                format.getInteger(MediaFormat.KEY_WIDTH)
+            } else {
+                currentWidth
+            }
+
+        outHeight =
+            if (format.containsKey(MediaFormat.KEY_HEIGHT)) {
+                format.getInteger(MediaFormat.KEY_HEIGHT)
+            } else {
+                currentHeight
+            }
+
+        outStride =
+            if (format.containsKey("stride")) {
+                format.getInteger("stride")
+            } else {
+                outWidth
+            }
+
+        outSliceHeight =
+            if (format.containsKey("slice-height")) {
+                format.getInteger("slice-height")
+            } else {
+                outHeight
+            }
+
+        pixelFormat =
+            when (colorFormat) {
+                1, 0x7F000789 -> VideoPixelFormat.RGBA
+                19, 20, 0x7F420888 -> VideoPixelFormat.YUV420P
+                21, 22 -> VideoPixelFormat.NV12
+                else -> VideoPixelFormat.YUV420P
+            }
+
+        diagLog(
+            "Output format: color-format=0x${colorFormat.toString(16)}, " +
+                "pixelFormat=$pixelFormat, " +
+                "size=${outWidth}x$outHeight, " +
+                "stride=$outStride, slice=$outSliceHeight",
+        )
+    }
+
+    private fun fillFrame(
+        codec: MediaCodec,
+        index: Int,
+        format: VideoPixelFormat,
+        width: Int,
+        height: Int,
+        frame: VideoFrame,
+    ): Boolean {
+        return when (format) {
+            VideoPixelFormat.YUV420P -> fillYuv420(codec, index, width, height, frame)
+            VideoPixelFormat.NV12 -> fillNv12(codec, index, width, height, frame)
+            VideoPixelFormat.RGBA -> fillRgba(codec, index, width, height, frame)
+        }
+    }
+
+    private fun fillYuv420(
+        codec: MediaCodec,
+        index: Int,
+        width: Int,
+        height: Int,
+        frame: VideoFrame,
+    ): Boolean {
+        val image =
+            try {
+                codec.getOutputImage(index)
+            } catch (e: Exception) {
+                diagLog("getOutputImage failed: ${e.message}")
+                null
+            }
+
+        if (image != null) {
+            try {
+                val planes = image.planes
+                if (planes.size < 3) return false
+
+                val yPlane = planes[0]
+                val uPlane = planes[1]
+                val vPlane = planes[2]
+
+                val y = frame.y ?: return false
+
+                copyPlane(
+                    yPlane.buffer,
+                    yPlane.rowStride,
+                    yPlane.pixelStride,
+                    width,
+                    height,
+                    y,
+                )
+
+                if (uPlane.pixelStride == 1 && vPlane.pixelStride == 1) {
+                    val u = frame.u ?: return false
+                    val v = frame.v ?: return false
+
+                    copyPlane(
+                        uPlane.buffer,
+                        uPlane.rowStride,
+                        uPlane.pixelStride,
+                        (width + 1) / 2,
+                        (height + 1) / 2,
+                        u,
+                    )
+
+                    copyPlane(
+                        vPlane.buffer,
+                        vPlane.rowStride,
+                        vPlane.pixelStride,
+                        (width + 1) / 2,
+                        (height + 1) / 2,
+                        v,
+                    )
+                } else {
+                    chromaInterleaved = true
+                    pixelFormat = VideoPixelFormat.NV12
+
+                    // The acquired frame has to match the actual output format.
+                    // This path is only used when Qualcomm exposes interleaved
+                    // chroma through flexible Image planes.
+                    val uv = frame.uv
+                    if (uv == null) {
+                        image.close()
+                        return false
+                    }
+
+                    copyInterleavedChroma(
+                        uPlane.buffer,
+                        vPlane.buffer,
+                        uPlane.rowStride,
+                        vPlane.rowStride,
+                        uPlane.pixelStride,
+                        vPlane.pixelStride,
+                        (width + 1) / 2,
+                        (height + 1) / 2,
+                        uv,
+                    )
+                }
+
+                return true
+            } finally {
+                image.close()
+            }
+        }
+
+        val buffer = codec.getOutputBuffer(index) ?: return false
+        val y = frame.y ?: return false
+        val u = frame.u ?: return false
+        val v = frame.v ?: return false
+
+        val chromaWidth = (width + 1) / 2
+        val chromaHeight = (height + 1) / 2
+        val ySize = width * height
+        val uvSize = chromaWidth * chromaHeight
+
+        if (buffer.remaining() < ySize + uvSize * 2) return false
+
+        buffer.get(y, 0, ySize)
+        buffer.get(u, 0, uvSize)
+        buffer.get(v, 0, uvSize)
+
+        return true
+    }
+
+    private fun fillNv12(
+        codec: MediaCodec,
+        index: Int,
+        width: Int,
+        height: Int,
+        frame: VideoFrame,
+    ): Boolean {
+        val image =
+            try {
+                codec.getOutputImage(index)
+            } catch (_: Exception) {
+                null
+            }
+
+        if (image != null) {
+            try {
+                val planes = image.planes
+                if (planes.size < 2) return false
+
+                val yPlane = planes[0]
+                val uvPlane = planes[1]
+
+                val y = frame.y ?: return false
+                val uv = frame.uv ?: return false
+
+                copyPlane(
+                    yPlane.buffer,
+                    yPlane.rowStride,
+                    yPlane.pixelStride,
+                    width,
+                    height,
+                    y,
+                )
+
+                copyPlaneInterleaved(
+                    uvPlane.buffer,
+                    uvPlane.rowStride,
+                    uvPlane.pixelStride,
+                    (width + 1) / 2,
+                    (height + 1) / 2,
+                    uv,
+                )
+
+                return true
+            } finally {
+                image.close()
+            }
+        }
+
+        val buffer = codec.getOutputBuffer(index) ?: return false
+        val y = frame.y ?: return false
+        val uv = frame.uv ?: return false
+
+        val ySize = width * height
+        val uvSize = ((width + 1) / 2) * ((height + 1) / 2) * 2
+
+        if (buffer.remaining() < ySize + uvSize) return false
+
+        buffer.get(y, 0, ySize)
+        buffer.get(uv, 0, uvSize)
+
+        return true
+    }
+
+    private fun fillRgba(
+        codec: MediaCodec,
+        index: Int,
+        width: Int,
+        height: Int,
+        frame: VideoFrame,
+    ): Boolean {
+        val rgba = frame.rgba ?: return false
+        val buffer = codec.getOutputBuffer(index) ?: return false
+        val required = width * height * 4
+
+        if (buffer.remaining() < required) return false
+
+        buffer.get(rgba, 0, required)
+        return true
+    }
+
+    private fun copyPlane(
+        src: ByteBuffer,
+        rowStride: Int,
+        pixelStride: Int,
+        width: Int,
+        height: Int,
+        dst: ByteArray,
+    ) {
+        val base = src.position()
+        val rowBytes = width
+
+        ensureScratch(rowBytes)
+
+        for (row in 0 until height) {
+            val rowStart = base + row * rowStride
+
+            if (pixelStride == 1) {
+                src.position(rowStart)
+                val count = minOf(width, src.limit() - rowStart)
+                if (count > 0) src.get(dst, row * width, count)
+
+                if (count < width) {
+                    java.util.Arrays.fill(
+                        dst,
+                        row * width + maxOf(count, 0),
+                        row * width + width,
+                        0x80.toByte(),
+                    )
+                }
+            } else {
+                val needed = width * pixelStride
+                ensureScratch(needed)
+
+                src.position(rowStart)
+                val count = minOf(needed, src.limit() - rowStart)
+
+                if (count > 0) src.get(planeScratch, 0, count)
+
+                val dstOffset = row * width
+                var x = 0
+                var out = 0
+
+                while (x < count && out < width) {
+                    dst[dstOffset + out] = planeScratch[x]
+                    x += pixelStride
+                    out++
+                }
+
+                while (out < width) {
+                    dst[dstOffset + out] = 0x80.toByte()
+                    out++
+                }
+            }
+        }
+
+        src.position(base)
+    }
+
+    private fun copyPlaneInterleaved(
+        src: ByteBuffer,
+        rowStride: Int,
+        pixelStride: Int,
+        width: Int,
+        height: Int,
+        dst: ByteArray,
+    ) {
+        val base = src.position()
+        val rowBytes = width * 2
+
+        for (row in 0 until height) {
+            val rowStart = base + row * rowStride
+            src.position(rowStart)
+
+            if (pixelStride == 2) {
+                val count = minOf(rowBytes, src.limit() - rowStart)
+                if (count > 0) src.get(dst, row * rowBytes, count)
+            } else {
+                val dstOffset = row * rowBytes
+                val count = minOf(width, src.limit() - rowStart)
+
+                var i = 0
+                while (i < count) {
+                    val value = src.get(rowStart + i)
+                    dst[dstOffset + i * 2] = value
+                    i++
+                }
+            }
+        }
+
+        src.position(base)
+    }
+
+    private fun copyInterleavedChroma(
+        u: ByteBuffer,
+        v: ByteBuffer,
+        uRowStride: Int,
+        vRowStride: Int,
+        uPixelStride: Int,
+        vPixelStride: Int,
+        width: Int,
+        height: Int,
+        dst: ByteArray,
+    ) {
+        val uBase = u.position()
+        val vBase = v.position()
+
+        for (row in 0 until height) {
+            val dstOffset = row * width * 2
+
+            for (x in 0 until width) {
+                val uPos = uBase + row * uRowStride + x * uPixelStride
+                val vPos = vBase + row * vRowStride + x * vPixelStride
+
+                if (uPos < u.limit()) dst[dstOffset + x * 2] = u.get(uPos)
+                if (vPos < v.limit()) dst[dstOffset + x * 2 + 1] = v.get(vPos)
+            }
+        }
+
+        u.position(uBase)
+        v.position(vBase)
+    }
+
+    private fun ensureScratch(size: Int) {
+        if (planeScratch.size < size) {
+            planeScratch = ByteArray(size)
         }
     }
 

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/VideoFrame.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/VideoFrame.kt
@@ -1,0 +1,44 @@
+package com.sidescreen.app
+
+class VideoFrame(
+    val format: VideoPixelFormat,
+    val width: Int,
+    val height: Int
+) {
+    val y: ByteArray?
+    val u: ByteArray?
+    val v: ByteArray?
+    val uv: ByteArray?
+    val rgba: ByteArray?
+
+    init {
+        val chromaWidth = (width + 1) / 2
+        val chromaHeight = (height + 1) / 2
+
+        when (format) {
+            VideoPixelFormat.YUV420P -> {
+                y = ByteArray(width * height)
+                u = ByteArray(chromaWidth * chromaHeight)
+                v = ByteArray(chromaWidth * chromaHeight)
+                uv = null
+                rgba = null
+            }
+
+            VideoPixelFormat.NV12 -> {
+                y = ByteArray(width * height)
+                u = null
+                v = null
+                uv = ByteArray(chromaWidth * chromaHeight * 2)
+                rgba = null
+            }
+
+            VideoPixelFormat.RGBA -> {
+                y = null
+                u = null
+                v = null
+                uv = null
+                rgba = ByteArray(width * height * 4)
+            }
+        }
+    }
+}

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/VideoFramePool.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/VideoFramePool.kt
@@ -1,0 +1,34 @@
+package com.sidescreen.app
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+class VideoFramePool {
+
+    private val pool = ConcurrentLinkedQueue<VideoFrame>()
+
+    fun acquire(
+        format: VideoPixelFormat,
+        width: Int,
+        height: Int
+    ): VideoFrame {
+        while (true) {
+            val frame = pool.poll() ?: return VideoFrame(format, width, height)
+
+            if (
+                frame.format == format &&
+                frame.width == width &&
+                frame.height == height
+            ) {
+                return frame
+            }
+        }
+    }
+
+    fun release(frame: VideoFrame) {
+        pool.offer(frame)
+    }
+
+    fun clear() {
+        pool.clear()
+    }
+}

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/VideoGLSurfaceView.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/VideoGLSurfaceView.kt
@@ -1,0 +1,757 @@
+package com.sidescreen.app
+
+import android.content.Context
+import android.opengl.EGL14
+import android.opengl.GLES20
+import android.opengl.GLSurfaceView
+import android.util.AttributeSet
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.FloatBuffer
+import java.util.concurrent.ArrayBlockingQueue
+import javax.microedition.khronos.egl.EGL10
+import javax.microedition.khronos.opengles.GL10
+import kotlin.math.min
+
+class VideoGLSurfaceView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : GLSurfaceView(context, attrs) {
+
+    var framePool: VideoFramePool? = null
+
+    private val pendingFrames = ArrayBlockingQueue<VideoFrame>(2)
+
+    private var flipHorizontal = false
+    private var flipVertical = false
+
+    private val renderer = VideoRenderer()
+
+    init {
+        setEGLContextClientVersion(2)
+        setRenderer(renderer)
+        renderMode = RENDERMODE_WHEN_DIRTY
+    }
+
+    fun pushFrame(frame: VideoFrame) {
+        if (!pendingFrames.offer(frame)) {
+            val old = pendingFrames.poll()
+            if (old != null) {
+                recycleFrame(old)
+            }
+
+            if (!pendingFrames.offer(frame)) {
+                recycleFrame(frame)
+                return
+            }
+        }
+
+        requestRender()
+    }
+
+    fun clearFrames() {
+        while (true) {
+            val frame = pendingFrames.poll() ?: break
+            recycleFrame(frame)
+        }
+
+        queueEvent {
+            renderer.clearCurrent()
+        }
+    }
+
+    fun setFlip(horizontal: Boolean, vertical: Boolean) {
+        flipHorizontal = horizontal
+        flipVertical = vertical
+        requestRender()
+    }
+
+    override fun onPause() {
+        renderer.releaseCurrent()
+        clearFrames()
+        super.onPause()
+    }
+
+    private fun recycleFrame(frame: VideoFrame) {
+        framePool?.release(frame)
+    }
+
+    private inner class VideoRenderer : GLSurfaceView.Renderer {
+
+        private var program = 0
+
+        private var aPosition = 0
+        private var aTexCoord = 0
+
+        private var uY = 0
+        private var uU = 0
+        private var uV = 0
+        private var uUV = 0
+        private var uRgba = 0
+        private var uHalfTexel = 0
+        private var uMode = 0
+
+        private var yTexture = 0
+        private var uTexture = 0
+        private var vTexture = 0
+        private var uvTexture = 0
+        private var rgbaTexture = 0
+
+        private var lastFrame: VideoFrame? = null
+
+        private var yWidth = -1
+        private var yHeight = -1
+
+        private var uWidth = -1
+        private var uHeight = -1
+
+        private var vWidth = -1
+        private var vHeight = -1
+
+        private var uvWidth = -1
+        private var uvHeight = -1
+
+        private var rgbaWidth = -1
+        private var rgbaHeight = -1
+
+        private var surfaceWidth = 0
+        private var surfaceHeight = 0
+
+        private val vertexBuffer: FloatBuffer =
+            ByteBuffer
+                .allocateDirect(4 * 4 * 4)
+                .order(ByteOrder.nativeOrder())
+                .asFloatBuffer()
+
+        override fun onSurfaceCreated(
+            gl: GL10?,
+            config: javax.microedition.khronos.egl.EGLConfig?
+        ) {
+            GLES20.glClearColor(0f, 0f, 0f, 1f)
+
+            EGL14.eglSwapInterval(
+                EGL14.eglGetCurrentDisplay(),
+                1
+            )
+
+            program = createProgram(VERTEX_SHADER, FRAGMENT_SHADER)
+
+            aPosition = GLES20.glGetAttribLocation(program, "aPosition")
+            aTexCoord = GLES20.glGetAttribLocation(program, "aTexCoord")
+
+            uY = GLES20.glGetUniformLocation(program, "uY")
+            uU = GLES20.glGetUniformLocation(program, "uU")
+            uV = GLES20.glGetUniformLocation(program, "uV")
+            uUV = GLES20.glGetUniformLocation(program, "uUV")
+            uRgba = GLES20.glGetUniformLocation(program, "uRgba")
+            uHalfTexel = GLES20.glGetUniformLocation(program, "uHalfTexel")
+            uMode = GLES20.glGetUniformLocation(program, "uMode")
+
+            val textures = IntArray(5)
+            GLES20.glGenTextures(5, textures, 0)
+
+            yTexture = textures[0]
+            uTexture = textures[1]
+            vTexture = textures[2]
+            uvTexture = textures[3]
+            rgbaTexture = textures[4]
+
+            GLES20.glUseProgram(program)
+
+            GLES20.glUniform1i(uY, 0)
+            GLES20.glUniform1i(uU, 1)
+            GLES20.glUniform1i(uV, 2)
+            GLES20.glUniform1i(uUV, 3)
+            GLES20.glUniform1i(uRgba, 4)
+        }
+
+        override fun onSurfaceChanged(
+            gl: GL10?,
+            width: Int,
+            height: Int
+        ) {
+            surfaceWidth = width
+            surfaceHeight = height
+
+            GLES20.glViewport(0, 0, width, height)
+        }
+
+        override fun onDrawFrame(gl: GL10?) {
+            GLES20.glClear(
+                GLES20.GL_COLOR_BUFFER_BIT
+            )
+
+            val nextFrame = pendingFrames.poll()
+
+            if (nextFrame != null) {
+                lastFrame?.let { recycleFrame(it) }
+                lastFrame = nextFrame
+            }
+
+            val frame = lastFrame ?: return
+
+            drawFrame(frame)
+        }
+
+        fun clearCurrent() {
+            lastFrame?.let {
+                recycleFrame(it)
+                lastFrame = null
+            }
+        }
+
+        fun releaseCurrent() {
+            lastFrame?.let {
+                recycleFrame(it)
+                lastFrame = null
+            }
+        }
+
+        private fun drawFrame(frame: VideoFrame) {
+            val width = frame.width
+            val height = frame.height
+
+            if (width <= 0 || height <= 0) {
+                return
+            }
+
+            val frameAspect = width.toFloat() / height.toFloat()
+            val viewAspect =
+                if (surfaceHeight == 0) {
+                    frameAspect
+                } else {
+                    surfaceWidth.toFloat() / surfaceHeight.toFloat()
+                }
+
+            var drawWidth = 1f
+            var drawHeight = 1f
+
+            if (frameAspect > viewAspect) {
+                drawHeight = viewAspect / frameAspect
+            } else {
+                drawWidth = frameAspect / viewAspect
+            }
+
+            val left = -drawWidth
+            val right = drawWidth
+            val top = drawHeight
+            val bottom = -drawHeight
+
+            val texLeft = if (flipHorizontal) 1f else 0f
+            val texRight = if (flipHorizontal) 0f else 1f
+            val texTop = if (flipVertical) 1f else 0f
+            val texBottom = if (flipVertical) 0f else 1f
+
+            val vertices = floatArrayOf(
+                left, bottom, texLeft, texBottom,
+                right, bottom, texRight, texBottom,
+                left, top, texLeft, texTop,
+                right, top, texRight, texTop
+            )
+
+            vertexBuffer.clear()
+            vertexBuffer.put(vertices)
+            vertexBuffer.position(0)
+
+            GLES20.glUseProgram(program)
+
+            vertexBuffer.position(0)
+            GLES20.glEnableVertexAttribArray(aPosition)
+            GLES20.glVertexAttribPointer(
+                aPosition,
+                2,
+                GLES20.GL_FLOAT,
+                false,
+                16,
+                vertexBuffer
+            )
+
+            vertexBuffer.position(2)
+            GLES20.glEnableVertexAttribArray(aTexCoord)
+            GLES20.glVertexAttribPointer(
+                aTexCoord,
+                2,
+                GLES20.GL_FLOAT,
+                false,
+                16,
+                vertexBuffer
+            )
+
+            when (frame.format) {
+                VideoPixelFormat.YUV420P -> {
+                    uploadYuv420(frame)
+                }
+
+                VideoPixelFormat.NV12 -> {
+                    uploadNv12(frame)
+                }
+
+                VideoPixelFormat.RGBA -> {
+                    uploadRgba(frame)
+                }
+            }
+
+            GLES20.glUniform1f(
+                uHalfTexel,
+                0.5f / width.toFloat()
+            )
+
+            GLES20.glDrawArrays(
+                GLES20.GL_TRIANGLE_STRIP,
+                0,
+                4
+            )
+
+            GLES20.glDisableVertexAttribArray(aPosition)
+            GLES20.glDisableVertexAttribArray(aTexCoord)
+        }
+
+        private fun uploadYuv420(frame: VideoFrame) {
+            val y = frame.y ?: return
+            val u = frame.u ?: return
+            val v = frame.v ?: return
+
+            GLES20.glUniform1i(uMode, MODE_YUV420)
+
+            uploadLuminance(
+                texture = yTexture,
+                unit = 0,
+                data = y,
+                width = frame.width,
+                height = frame.height
+            )
+
+            uploadLuminance(
+                texture = uTexture,
+                unit = 1,
+                data = u,
+                width = (frame.width + 1) / 2,
+                height = (frame.height + 1) / 2
+            )
+
+            uploadLuminance(
+                texture = vTexture,
+                unit = 2,
+                data = v,
+                width = (frame.width + 1) / 2,
+                height = (frame.height + 1) / 2
+            )
+        }
+
+        private fun uploadNv12(frame: VideoFrame) {
+            val y = frame.y ?: return
+            val uv = frame.uv ?: return
+
+            GLES20.glUniform1i(uMode, MODE_NV12)
+
+            uploadLuminance(
+                texture = yTexture,
+                unit = 0,
+                data = y,
+                width = frame.width,
+                height = frame.height
+            )
+
+            uploadLuminanceAlpha(
+                texture = uvTexture,
+                unit = 3,
+                data = uv,
+                width = (frame.width + 1) / 2,
+                height = (frame.height + 1) / 2
+            )
+        }
+
+        private fun uploadRgba(frame: VideoFrame) {
+            val rgba = frame.rgba ?: return
+
+            GLES20.glUniform1i(uMode, MODE_RGBA)
+
+            GLES20.glActiveTexture(
+                GLES20.GL_TEXTURE4
+            )
+
+            GLES20.glBindTexture(
+                GLES20.GL_TEXTURE_2D,
+                rgbaTexture
+            )
+
+            configureTexture()
+
+            if (
+                rgbaWidth != frame.width ||
+                rgbaHeight != frame.height
+            ) {
+                GLES20.glTexImage2D(
+                    GLES20.GL_TEXTURE_2D,
+                    0,
+                    GLES20.GL_RGBA,
+                    frame.width,
+                    frame.height,
+                    0,
+                    GLES20.GL_RGBA,
+                    GLES20.GL_UNSIGNED_BYTE,
+                    ByteBuffer.wrap(rgba)
+                )
+
+                rgbaWidth = frame.width
+                rgbaHeight = frame.height
+            } else {
+                GLES20.glTexSubImage2D(
+                    GLES20.GL_TEXTURE_2D,
+                    0,
+                    0,
+                    0,
+                    frame.width,
+                    frame.height,
+                    GLES20.GL_RGBA,
+                    GLES20.GL_UNSIGNED_BYTE,
+                    ByteBuffer.wrap(rgba)
+                )
+            }
+        }
+
+        private fun uploadLuminance(
+            texture: Int,
+            unit: Int,
+            data: ByteArray,
+            width: Int,
+            height: Int
+        ) {
+            GLES20.glActiveTexture(
+                GLES20.GL_TEXTURE0 + unit
+            )
+
+            GLES20.glBindTexture(
+                GLES20.GL_TEXTURE_2D,
+                texture
+            )
+
+            configureTexture()
+
+            val needsAllocation =
+                when (texture) {
+                    yTexture ->
+                        yWidth != width || yHeight != height
+
+                    uTexture ->
+                        uWidth != width || uHeight != height
+
+                    vTexture ->
+                        vWidth != width || vHeight != height
+
+                    else -> true
+                }
+
+            if (needsAllocation) {
+                GLES20.glTexImage2D(
+                    GLES20.GL_TEXTURE_2D,
+                    0,
+                    GLES20.GL_LUMINANCE,
+                    width,
+                    height,
+                    0,
+                    GLES20.GL_LUMINANCE,
+                    GLES20.GL_UNSIGNED_BYTE,
+                    ByteBuffer.wrap(data)
+                )
+
+                when (texture) {
+                    yTexture -> {
+                        yWidth = width
+                        yHeight = height
+                    }
+
+                    uTexture -> {
+                        uWidth = width
+                        uHeight = height
+                    }
+
+                    vTexture -> {
+                        vWidth = width
+                        vHeight = height
+                    }
+                }
+            } else {
+                GLES20.glTexSubImage2D(
+                    GLES20.GL_TEXTURE_2D,
+                    0,
+                    0,
+                    0,
+                    width,
+                    height,
+                    GLES20.GL_LUMINANCE,
+                    GLES20.GL_UNSIGNED_BYTE,
+                    ByteBuffer.wrap(data)
+                )
+            }
+        }
+
+        private fun uploadLuminanceAlpha(
+            texture: Int,
+            unit: Int,
+            data: ByteArray,
+            width: Int,
+            height: Int
+        ) {
+            GLES20.glActiveTexture(
+                GLES20.GL_TEXTURE0 + unit
+            )
+
+            GLES20.glBindTexture(
+                GLES20.GL_TEXTURE_2D,
+                texture
+            )
+
+            configureTexture()
+
+            val needsAllocation =
+                uvWidth != width || uvHeight != height
+
+            if (needsAllocation) {
+                GLES20.glTexImage2D(
+                    GLES20.GL_TEXTURE_2D,
+                    0,
+                    GLES20.GL_LUMINANCE_ALPHA,
+                    width,
+                    height,
+                    0,
+                    GLES20.GL_LUMINANCE_ALPHA,
+                    GLES20.GL_UNSIGNED_BYTE,
+                    ByteBuffer.wrap(data)
+                )
+
+                uvWidth = width
+                uvHeight = height
+            } else {
+                GLES20.glTexSubImage2D(
+                    GLES20.GL_TEXTURE_2D,
+                    0,
+                    0,
+                    0,
+                    width,
+                    height,
+                    GLES20.GL_LUMINANCE_ALPHA,
+                    GLES20.GL_UNSIGNED_BYTE,
+                    ByteBuffer.wrap(data)
+                )
+            }
+        }
+
+        private fun configureTexture() {
+            GLES20.glTexParameteri(
+                GLES20.GL_TEXTURE_2D,
+                GLES20.GL_TEXTURE_MIN_FILTER,
+                GLES20.GL_LINEAR
+            )
+
+            GLES20.glTexParameteri(
+                GLES20.GL_TEXTURE_2D,
+                GLES20.GL_TEXTURE_MAG_FILTER,
+                GLES20.GL_LINEAR
+            )
+
+            GLES20.glTexParameteri(
+                GLES20.GL_TEXTURE_2D,
+                GLES20.GL_TEXTURE_WRAP_S,
+                GLES20.GL_CLAMP_TO_EDGE
+            )
+
+            GLES20.glTexParameteri(
+                GLES20.GL_TEXTURE_2D,
+                GLES20.GL_TEXTURE_WRAP_T,
+                GLES20.GL_CLAMP_TO_EDGE
+            )
+        }
+    }
+
+    private companion object {
+        const val MODE_YUV420 = 0
+        const val MODE_NV12 = 1
+        const val MODE_RGBA = 2
+
+        val VERTEX_SHADER = """
+            attribute vec4 aPosition;
+            attribute vec2 aTexCoord;
+
+            varying vec2 vTexCoord;
+
+            void main() {
+                gl_Position = aPosition;
+                vTexCoord = aTexCoord;
+            }
+        """.trimIndent()
+
+        val FRAGMENT_SHADER = """
+            precision mediump float;
+
+            varying vec2 vTexCoord;
+
+            uniform sampler2D uY;
+            uniform sampler2D uU;
+            uniform sampler2D uV;
+            uniform sampler2D uUV;
+            uniform sampler2D uRgba;
+
+            uniform float uHalfTexel;
+            uniform int uMode;
+
+            void main() {
+                if (uMode == 2) {
+                    gl_FragColor = texture2D(
+                        uRgba,
+                        vTexCoord
+                    );
+                    return;
+                }
+
+                float y = texture2D(
+                    uY,
+                    vTexCoord
+                ).r;
+
+                float u;
+                float v;
+
+                if (uMode == 0) {
+                    vec2 chromaCoord =
+                        vTexCoord +
+                        vec2(uHalfTexel, uHalfTexel);
+
+                    u = texture2D(
+                        uU,
+                        chromaCoord
+                    ).r - 0.5;
+
+                    v = texture2D(
+                        uV,
+                        chromaCoord
+                    ).r - 0.5;
+                } else {
+                    vec2 uv =
+                        texture2D(
+                            uUV,
+                            vTexCoord +
+                            vec2(uHalfTexel, uHalfTexel)
+                        ).ra;
+
+                    u = uv.x - 0.5;
+                    v = uv.y - 0.5;
+                }
+
+                // BT.709 full-range YUV -> RGB.
+                float r =
+                    y +
+                    1.402 * v;
+
+                float g =
+                    y -
+                    0.344136 * u -
+                    0.714136 * v;
+
+                float b =
+                    y +
+                    1.772 * u;
+
+                gl_FragColor = vec4(
+                    clamp(r, 0.0, 1.0),
+                    clamp(g, 0.0, 1.0),
+                    clamp(b, 0.0, 1.0),
+                    1.0
+                );
+            }
+        """.trimIndent()
+
+        fun loadShader(
+            type: Int,
+            source: String
+        ): Int {
+            val shader = GLES20.glCreateShader(type)
+
+            GLES20.glShaderSource(
+                shader,
+                source
+            )
+
+            GLES20.glCompileShader(shader)
+
+            val compiled = IntArray(1)
+
+            GLES20.glGetShaderiv(
+                shader,
+                GLES20.GL_COMPILE_STATUS,
+                compiled,
+                0
+            )
+
+            if (compiled[0] == 0) {
+                val error =
+                    GLES20.glGetShaderInfoLog(shader)
+
+                GLES20.glDeleteShader(shader)
+
+                throw RuntimeException(
+                    "Shader compilation failed: $error"
+                )
+            }
+
+            return shader
+        }
+
+        fun createProgram(
+            vertexSource: String,
+            fragmentSource: String
+        ): Int {
+            val vertexShader =
+                loadShader(
+                    GLES20.GL_VERTEX_SHADER,
+                    vertexSource
+                )
+
+            val fragmentShader =
+                loadShader(
+                    GLES20.GL_FRAGMENT_SHADER,
+                    fragmentSource
+                )
+
+            val program =
+                GLES20.glCreateProgram()
+
+            GLES20.glAttachShader(
+                program,
+                vertexShader
+            )
+
+            GLES20.glAttachShader(
+                program,
+                fragmentShader
+            )
+
+            GLES20.glLinkProgram(program)
+
+            val linked = IntArray(1)
+
+            GLES20.glGetProgramiv(
+                program,
+                GLES20.GL_LINK_STATUS,
+                linked,
+                0
+            )
+
+            if (linked[0] == 0) {
+                val error =
+                    GLES20.glGetProgramInfoLog(program)
+
+                GLES20.glDeleteProgram(program)
+
+                throw RuntimeException(
+                    "Program linking failed: $error"
+                )
+            }
+
+            GLES20.glDeleteShader(vertexShader)
+            GLES20.glDeleteShader(fragmentShader)
+
+            return program
+        }
+    }
+}

--- a/AndroidClient/app/src/main/java/com/sidescreen/app/VideoPixelFormat.kt
+++ b/AndroidClient/app/src/main/java/com/sidescreen/app/VideoPixelFormat.kt
@@ -1,0 +1,7 @@
+package com.sidescreen.app
+
+enum class VideoPixelFormat {
+    YUV420P,
+    NV12,
+    RGBA
+}

--- a/AndroidClient/app/src/main/res/layout/activity_main.xml
+++ b/AndroidClient/app/src/main/res/layout/activity_main.xml
@@ -6,21 +6,11 @@
     android:layout_height="match_parent"
     android:background="#000000">
 
-    <!-- Video Surface -->
-    <SurfaceView
-        android:id="@+id/surfaceView"
+    <!-- Path B: app-controlled YUV -> RGB rendering -->
+    <com.sidescreen.app.VideoGLSurfaceView
+        android:id="@+id/videoView"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
-
-    <TextureView
-        android:id="@+id/textureView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:visibility="gone"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## Problem

Some light gray colors in the SideScreen video stream were rendered as white on some Android tablets.

For example:

- `#F1F3F4` was rendered as white on the Android display
- The same color appeared correctly as light gray on the Mac display

The issue was reproduced on a Samsung Galaxy Tab S7 FE (SM-T736B) running Android 14.

## Root cause

The Android client previously decoded HEVC directly into a `SurfaceView` using the vendor display/compositor path.

The decoder correctly reports the stream as BT.709 / SDR / full-range, but on affected devices the vendor YUV→RGB presentation path can apply a limited-range matrix regardless of the full-range flag.

This causes light grayscale values to be clipped toward white. For example, `#F1F3F4` was displayed as white even though the source frame contained the correct light-gray value.

Changing the `SurfaceView` dataspace alone did not resolve the issue.

## Fix

Replace the zero-copy `MediaCodec` → `SurfaceView` rendering path with an application-controlled rendering path:

- Configure `MediaCodec` for byte-buffer/Image output instead of decoding directly to a `Surface`.
- Extract decoded YUV frames using `MediaCodec.getOutputImage()` / output buffers.
- Handle flexible YUV420 layouts and interleaved NV12/QTI output.
- Reuse decoded frame buffers with a small frame pool.
- Use a bounded render queue to prevent excessive frame buffering.
- Render frames through a custom `GLSurfaceView`.
- Perform explicit BT.709 full-range YUV→RGB conversion in the GLSL fragment shader.
- Bypass the affected vendor YUV→RGB conversion path.
- Preserve frame-drop, stale-output handling, and keyframe recovery.
- Keep the existing Mac capture, encoder, and stream format unchanged.

## Validation

Tested on:

- Samsung Galaxy Tab S7 FE (SM-T736B)
- Android 14
- USB-C connection
- Default installed SideScreen Mac application
- Custom terminal-built MacHost

Verified correct rendering at:

- `1280×800`
- `1920×1200`
- `2560×1600`

Also tested with:

- Ultra Low
- Medium
- High

The light-gray test color `#F1F3F4` now remains visibly gray instead of being clipped to white.

## Scope

This PR replaces the previous SurfaceView dataspace-only approach with an application-controlled YUV→RGB rendering path.

No Mac-side encoder or capture changes are required.

The fix is implemented entirely on the Android client.