### PR TITLE
fix: keep the stream alive across keyboard and dark-theme configuration changes

### DIFF
--- a/AndroidClient/app/src/main/AndroidManifest.xml
+++ b/AndroidClient/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         <activity
             android:name=".MainActivity"
             android:screenOrientation="fullUser"
-            android:configChanges="orientation|screenSize|screenLayout"
+            android:configChanges="orientation|screenSize|screenLayout|keyboard|keyboardHidden|navigation"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/AndroidClient/app/src/main/AndroidManifest.xml
+++ b/AndroidClient/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         <activity
             android:name=".MainActivity"
             android:screenOrientation="fullUser"
-            android:configChanges="orientation|screenSize|screenLayout|keyboard|keyboardHidden|navigation"
+            android:configChanges="orientation|screenSize|screenLayout|keyboard|keyboardHidden|navigation|uiMode"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Bluetooth keyboard no longer drops the connection.** Connecting or disconnecting a Bluetooth keyboard on the tablet changed `keyboard`/`keyboardHidden`/`navigation` in the Android configuration; `MainActivity` didn't declare those in `configChanges`, so Android destroyed and recreated it mid-stream — `onDestroy` ran `cleanup()`, which closed the socket, and the Mac logged `Connection reset by peer`. Since nothing is restored on recreation, the tablet sat on the connect screen until you tapped connect again. Affects USB and wireless alike.
+
 ### Planned
 - mDNS auto-discovery for wireless mode
 - Audio streaming

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **Bluetooth keyboard no longer drops the connection.** Connecting or disconnecting a Bluetooth keyboard on the tablet changed `keyboard`/`keyboardHidden`/`navigation` in the Android configuration; `MainActivity` didn't declare those in `configChanges`, so Android destroyed and recreated it mid-stream — `onDestroy` ran `cleanup()`, which closed the socket, and the Mac logged `Connection reset by peer`. Since nothing is restored on recreation, the tablet sat on the connect screen until you tapped connect again. Affects USB and wireless alike.
+- **Configuration changes no longer drop the connection.** Connecting or disconnecting a Bluetooth keyboard on the tablet changed `keyboard`/`keyboardHidden`/`navigation` in the Android configuration; `MainActivity` didn't declare those in `configChanges`, so Android destroyed and recreated it mid-stream — `onDestroy` ran `cleanup()`, which closed the socket, and the Mac logged `Connection reset by peer`. Since nothing is restored on recreation, the tablet sat on the connect screen until you tapped connect again. Affects USB and wireless alike. The same path fired on an automatic dark-theme switch (`uiMode`), so a tablet left streaming across sunset dropped too; both dimensions are now declared.
 
 ### Planned
 - mDNS auto-discovery for wireless mode


### PR DESCRIPTION
## The problem

Two different, unrelated-looking events kill the stream mid-session. The tablet drops back to the connect screen and you have to reconnect by hand. Both affect USB and wireless alike.

1. **Connecting or disconnecting a Bluetooth keyboard on the tablet.**
2. **An automatic dark-theme switch** — this one fires with nobody touching the device. A tablet left running as a second display across sunset, with "Dark theme: sunset to sunrise" on, drops the stream by itself.

I couldn't find existing issues for either, so the report is here.

## Root cause

One defect, two triggers. `MainActivity` doesn't declare the affected dimensions in `android:configChanges`, so Android destroys and recreates the activity — and `onDestroy` runs `cleanup()`, which calls `disconnect()`.

WindowManager states the decision itself. Keyboard:

```
D/WindowManager: Checking to restart com.sidescreen.app.MainActivity:
  changed     = {CONFIG_KEYBOARD_HIDDEN, CONFIG_NAVIGATION}
  handles     = {CONFIG_MCC, CONFIG_MNC, CONFIG_ORIENTATION, CONFIG_SCREEN_LAYOUT, CONFIG_SCREEN_SIZE}
  not-handles = {CONFIG_KEYBOARD_HIDDEN, CONFIG_NAVIGATION}      <- non-empty => restart
```

Dark theme:

```
  changed     = {CONFIG_UI_MODE}
  not-handles = {CONFIG_UI_MODE}                                  <- non-empty => restart
```

The chain is the same in both cases:

```
trigger (keyboard attach/detach, or night-mode flip)
  -> Configuration change the activity doesn't declare
  -> WindowManager recreates MainActivity
  -> onDestroy -> cleanup() -> disconnect()          (MainActivity.kt)
  -> Mac: Connection state: failed(POSIXErrorCode(54): Connection reset by peer)
```

The Mac side is only reacting — `reset by peer` means the tablet closed the socket.

Recreation is unrecoverable here because `MainActivity` has no `onSaveInstanceState` use and no auto-reconnect in `onCreate`, so there's nothing to resume from.

Every flag added was observed in a `changed=` set, not guessed: `CONFIG_KEYBOARD`, `CONFIG_KEYBOARD_HIDDEN`, `CONFIG_NAVIGATION`, `CONFIG_UI_MODE`.

## The fix

```diff
- android:configChanges="orientation|screenSize|screenLayout"
+ android:configChanges="orientation|screenSize|screenLayout|keyboard|keyboardHidden|navigation|uiMode"
```

No `onConfigurationChanged` override is needed, and nothing depends on the recreation:

- nothing reads `Configuration.keyboard`, `.navigation` or `.uiMode`
- there are no keyboard- or navigation-qualified resource directories
- there is no `res/values-night` and no `AppCompatDelegate.setDefaultNightMode` call, even though `AppTheme` derives from `Theme.MaterialComponents.DayNight.NoActionBar`

## Verification

Galaxy Tab S8 Ultra (SM-X900), Android 15, USB mode, streaming throughout. The decisive signal is the `not-handles` set, since `Checking to restart` is logged for every check, not only for restarts.

**Keyboard** — AULA F87 Pro toggled while streaming:

| | keyboard events | config checks | forced restarts | Mac disconnects | streaming |
|---|---|---|---|---|---|
| before | 15 | 7 | **7** | repeated | broken loop |
| after | 16 | 8 | **0** | **0** | **126 s, `dropped: 0`** |

**Dark theme** — `adb shell cmd uimode night yes/no` while streaming:

| | config checks | forced restarts | Mac disconnects | streaming |
|---|---|---|---|---|
| before | 2 | **2** | **4× reset by peer** | dropped |
| after | 2 | **0** | **0** | **unbroken second-by-second through both toggles, `dropped: 0`** |

`./gradlew assembleRelease test` passes on this branch.

## Notes

- Behaviour only; no protocol or wire-format change, so old and new hosts are unaffected in both directions.
- Deliberately left out of this PR, but the same class of trigger: `smallestScreenSize` (split-screen enter/resize) and `density` / `fontScale` (Display size / Font size changes) are still undeclared and would drop the stream the same way. Happy to add them here or in a follow-up, whichever you prefer.
- Separately, `MainActivity` uses the default `launchMode`, so two instances can end up in one task and fight over the single-client server. I hit that through `adb am start`, so I don't know whether a real user path reaches it — flagging it rather than changing it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABR6vPUVPQZndK2AYH4vrJ
